### PR TITLE
Attempted adding DISTRO-updates to apt mirrors for all builds for hydro

### DIFF
--- a/hydro/doc-build.yaml
+++ b/hydro/doc-build.yaml
@@ -15,6 +15,7 @@ targets:
     - http://localhost/building/ubuntu DISTRO main
     - http://packages.ros.org/ros/ubuntu DISTRO main
     - http://archive.ubuntu.com/ubuntu DISTRO main universe
+    - http://archive.ubuntu.com/ubuntu DISTRO-updates main universe
     apt_keys:
     - http://localhost/public.key
     - http://packages.ros.org/ros.key

--- a/hydro/release-build.yaml
+++ b/hydro/release-build.yaml
@@ -11,6 +11,7 @@ targets:
     - http://localhost/building/ubuntu DISTRO main
     - http://packages.ros.org/ros/ubuntu DISTRO main
     - http://archive.ubuntu.com/ubuntu DISTRO main universe
+    - http://archive.ubuntu.com/ubuntu DISTRO-updates main universe
     apt_keys:
     - http://localhost/public.key
     - http://packages.ros.org/ros.key

--- a/hydro/source-build.yaml
+++ b/hydro/source-build.yaml
@@ -12,6 +12,7 @@ targets:
     - http://localhost/building/ubuntu DISTRO main
     - http://packages.ros.org/ros/ubuntu DISTRO main
     - http://archive.ubuntu.com/ubuntu DISTRO main universe
+    - http://archive.ubuntu.com/ubuntu DISTRO-updates main universe
     apt_keys:
     - http://localhost/public.key
     - http://packages.ros.org/ros.key


### PR DESCRIPTION
Part of a fix for building packages for hydro using buildbot_ros. See discussion and my comment on this GitHub issue: https://github.com/mikeferguson/buildbot-ros/issues/46#issuecomment-65070224
