### PR TITLE
kingfisher_firmware: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,4 +1,6 @@
 %YAML 1.1
+# ROS distribution file
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   ubuntu:
@@ -36,5 +38,23 @@ repositories:
       type: git
       url: https://github.com/jackal/jackal_robot.git
       version: indigo-devel
+  kingfisher_firmware:
+    doc:
+      type: git
+      url: https://bitbucket.org/clearpathrobotics/kingfisher_firmware.git
+      version: indigo-devel
+    release:
+      packages:
+      - kingfisher_avr
+      - kingfisher_firmware
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://bitbucket.org/clearpathrobotics/kingfisher_firmware-gbp.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://bitbucket.org/clearpathrobotics/kingfisher_firmware.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher_firmware` to `0.2.0-0`:
- upstream repository: https://bitbucket.org/clearpathrobotics/kingfisher_firmware.git
- release repository: https://bitbucket.org/clearpathrobotics/kingfisher_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## kingfisher_avr

```
* Remove unnecessary ros.h header.
* Reformat with astyle.
* Remove commented-out sections.
* Migrate away from rosserial_leonardo_cmake.
* Contributors: Mike Purvis
```
## kingfisher_firmware
- No changes
