### PR TITLE
kingfisher_firmware: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6,12 +6,6 @@ release_platforms:
   ubuntu:
   - trusty
 repositories:
-#imu_filter_madgwick:
-#    release:
-#      tags:
-#        release: release/indigo/{package}/{version}
-#      url: https://github.com/uos-gbp/imu_tools-release.git
-#      version: 1.0.1-0
   jackal_firmware:
     source:
       type: git
@@ -34,7 +28,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/kingfisher_firmware-gbp.git
-      version: 0.2.0-1
+      version: 0.2.2-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/kingfisher_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher_firmware` to `0.2.2-0`:
- upstream repository: https://bitbucket.org/clearpathrobotics/kingfisher_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/kingfisher_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.2.0-1`
## kingfisher_avr

```
* rosrun -> rosbash
* Contributors: Mike Purvis
```
## kingfisher_firmware
- No changes
