### PR TITLE
jackal_firmware: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13,10 +13,20 @@ repositories:
       url: https://github.com/uos-gbp/imu_tools-release.git
       version: 1.0.1-0
   jackal_firmware:
+    doc:
+      type: git
+      url: git@bitbucket.org:clearpathrobotics/jackal_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
+      version: 0.2.0-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware.git
       version: indigo-devel
+    status: maintained
   jackal_robot:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.2.0-0`:
- upstream repository: git@bitbucket.org:clearpathrobotics/jackal_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## jackal_firmware

```
* Add stm32plus build dep.
* Unsubmodule stm32-lib.
* Add magnetometer, with low pass filter.
* changed averaging to exponential moving averaging to increase the freq.
* Add IMU functionality.
* ROS comms status on HMI.
* Delayed motor enable, status on HMI light.
* Drive control disabled when motor disabled or faulted.
* More time before giving up on USB connection.
* Changed velocity control constants
* Contributors: Mike Purvis, Shokoofeh Pourmehr
```
