### PR TITLE
grizzly_firmware: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -18,6 +18,23 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly-release.git
       version: 0.3.0-0
+  grizzly_firmware:
+    doc:
+      type: git
+      url: git@bitbucket.org:clearpathrobotics/grizzly_firmware.git
+      version: indigo-devel
+    release:
+      packages:
+      - grizzly_avr
+      - grizzly_firmware
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:clearpathrobotics/grizzly_firmware-gbp.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: git@bitbucket.org:clearpathrobotics/grizzly_firmware.git
+      version: indigo-devel
   imu_filter_madgwick:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_firmware` to `0.2.0-0`:
- upstream repository: git@bitbucket.org:clearpathrobotics/grizzly_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/grizzly_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## grizzly_avr

```
* Move arduino rules from grizzly_bringup to here.
* Add bootloader and load scripts.
* Fix blower status output.
* Port firmware to rosserial_client.
* Contributors: Mike Purvis
```
## grizzly_firmware
- No changes
