### PR TITLE
jackal_robot: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -88,10 +88,24 @@ repositories:
       version: indigo-devel
     status: maintained
   jackal_robot:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: indigo-devel
+    release:
+      packages:
+      - jackal_base
+      - jackal_bringup
+      - jackal_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_robot-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git
       version: indigo-devel
+    status: maintained
   kingfisher_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.2.0-0`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`

## jackal_base

```
* read mag msg in radian.
* added magnetometer calibration computation scripts.
* Contributors: Shokoofeh Pourmehr
```

## jackal_bringup

```
* Add install script.
* Contributors: Mike Purvis
```

## jackal_robot

```
* Add jackal_bringup to robot metapackage.
* Contributors: Mike Purvis
```
