### PR TITLE
jackal_robot: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -100,7 +100,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.2.2-0`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.1-0`

## jackal_base

```
* Simplify mag computation.
* Don't output stderr from env hook.
* A new approach to fallback configuration.
* Add more missing dependencies to jackal_base.
* Add default compass configuration and install it.
* Remove sixpair, use system one instead.
* Contributors: Mike Purvis
```

## jackal_bringup

```
* Add default compass configuration and install it.
* Contributors: Mike Purvis
```

## jackal_robot

- No changes
