### PR TITLE
jackal: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -61,17 +61,25 @@ repositories:
       url: https://github.com/uos-gbp/imu_tools-release.git
       version: 1.0.1-0
   jackal:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: indigo-devel
     release:
       packages:
       - jackal_control
       - jackal_description
-      - jackal_diff_drive_controller
       - jackal_msgs
       - jackal_navigation
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.4.0-0
+      version: 0.4.2-0
+    source:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: indigo-devel
+    status: maintained
   jackal_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.4.2-0`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.4.0-0`

## jackal_control

```
* Shorten timeout for the controller spawner's shutdown.
* Contributors: Mike Purvis
```

## jackal_description

- No changes

## jackal_msgs

- No changes

## jackal_navigation

- No changes
