### PR TITLE
robot_upstart: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -141,7 +141,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.1.1-0`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.0-0`

## robot_upstart

```
* Python Rewrite
* The startup event is too early for ROS to start, use local-filesystems instead.
* Remove bash versions of the install and uninstall utilities.
* Add support for supplying the --wait flag to roslaunch.
* Add Sphinx documentation.
  To get the argparse docs required moving most of the install
  script to a module, which probably should have been done anyway.
* Add a new-implementation install script, refactor Provider to be a class rather than function.
* Add roslint.
* Initial implementation of Python job generator.
* Port templated files to use empy.
  This gets rid of the bespoke templating system that was so bad. Also
  notable here is adding a --root flag to install somewhere other than
  the actual root. This needs to be further fleshed out, for example
  by not reinvoking with sudo when installing to non-root location.
* use LANG=C for ifconfig
* add argument to specify log directory
* Contributors: Eisoku Kuroiwa, Mike Purvis, ipa-mig
```
