### PR TITLE
lms1xx: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -132,6 +132,12 @@ repositories:
       url: git@bitbucket.org:clearpathrobotics/kingfisher_firmware.git
       version: indigo-devel
     status: maintained
+  lms1xx:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/LMS1xx-release.git
+      version: 0.1.1-0
   robot_upstart:
     doc:
       type: git
@@ -141,7 +147,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.1.1-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.1-0`:

- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/LMS1xx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`

## lms1xx

```
* Changed the pkg and name so that the launch file is able to find the package.
* Fix assignment in if() to comparison.
* Contributors: Jeff Schmidt, Mike Purvis
```
