### PR TITLE
lms1xx: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -137,7 +137,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/LMS1xx-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.2-0`:

- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/LMS1xx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-0`

## lms1xx

```
* More robust startup for LMS1xs, retries instead of just dying.
* Switch to console_bridge logouts, separate lib.
* Remove buffer flush at conclusion.
* Use LMS1xx reported configuration instead of capabilities for angle_min, max, etc...
* Use output range query for min & max angles, num_values, and time_increment.
  Previously, the code would query the LMS1xx for its capabilities, which
  might exceed its current configuration (in terms of angle range).  Now, we
  query the LMS1xx for its configuration when setting scan parameters such
  as min & max angle, number of values reported, and time increment.
* Add getScanOutputRange() to read outputRange data from the LMS1xx.
* Contributors: Mike Purvis, Patrick Doyle
```
