### PR TITLE
jackal: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -195,18 +195,18 @@ repositories:
       url: https://github.com/husky/husky_viz.git
       version: indigo-devel
     status: maintained
-  imu_transformer:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/imu_pipeline-release.git
-      version: 0.2.0-0
   imu_filter_madgwick:
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
       version: 1.0.3-0
+  imu_transformer:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/imu_pipeline-release.git
+      version: 0.2.0-0
   jackal:
     doc:
       type: git
@@ -221,7 +221,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.5.1-0`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.5.0-0`

## jackal_control

- No changes

## jackal_description

```
* Modified the accessories.urdf.xacro to include both the GPS and mount plate, including standoffs.
* Eliminate rosrun from the xacro wrapper.
* Contributors: BryceVoort, Mike Purvis
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
