### PR TITLE
kingfisher_firmware: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1,4 +1,6 @@
 %YAML 1.1
+# ROS distribution file
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   ubuntu:
@@ -45,7 +47,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/kingfisher_firmware-gbp.git
-      version: 0.1.0-0
+      version: 0.1.1-0
   kingfisher_robot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher_firmware` to `0.1.1-0`:

- upstream repository: https://bitbucket.org/clearpathrobotics/kingfisher_firmware
- release repository: git@bitbucket.org:clearpathrobotics/kingfisher_firmware-gbp.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.0-0`

## kingfisher_avr

```
* Add rosserial_arduino as a run depend, per catkin warning.
* Contributors: Mike Purvis
```

## kingfisher_firmware

- No changes
