### PR TITLE
jackal_firmware: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -236,7 +236,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.0-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/jackal_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.1-0`

## jackal_firmware

```
* For released builds, use the package.xml version as the hardware ID.
* Add wifi LED support, zeroing of non-implemented temperature values.
* Dramatically reduce startup delay, now that controller issue is resolved.
* New approach to capturing NMEA sentences, GPS now enabled.
* Extend power-off deadline to 10 seconds.
  When equipped with a lot of USB payloads, there's a longer
  gap on startup between the USB ports coming alive, which
  caused one of the units to preemptively power itself off.
* Add short delays to IMU bringup; improves robustness.
* Pass only first-found binary to upload script.
* Contributors: Mike Purvis
```
