### PR TITLE
jackal_robot: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -255,7 +255,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.3.1-1
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.3.2-0`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.1-1`

## jackal_base

```
* Add simple connection detect to enable Jackal's wifi status LED.
* Get elapsed time from monotonic time source
* Contributors: Mike Purvis, Paul Bovbel
```

## jackal_bringup

```
* Retry on startup when network device does not exist.
* Set args types to int.
* Contributors: Mike Purvis
```

## jackal_robot

- No changes
