### PR TITLE
jackal_firmware: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -236,7 +236,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.1-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/jackal_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.0-0`

## jackal_firmware

```
* Populate drivers fields.
* Contributors: Mike Purvis
```
