### PR TITLE
kingfisher_robot: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -57,7 +57,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/kingfisher_robot-gbp.git
-      version: 0.0.4-0
+      version: 0.0.5-0
   kingfisher_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher_robot` to `0.0.5-0`:

- upstream repository: https://github.com/kf/kingfisher_robot
- release repository: git@bitbucket.org:clearpathrobotics/kingfisher_robot-gbp.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.4-0`

## kingfisher_bringup

```
* Add echosounder nmea topic
* Changed sensor to sonar to be more descriptive.
* set ublox back as default. Minor syntax changes.
* Setup sonar, gps, rtcm
* changes to nmea gps and serial bringup and added rtcm netserial stream
* Contributors: Andrew Blakey, Graeme Yeates, Mike Purvis, andrew_blakey
```

## kingfisher_nmea

```
* Instantiate Helm and Course classes as well as Drive.
* Fix topic name for Hydro, will change back on Indigo.
* Remove screen output tags from launch file.
* Add C++ implementation of command_publisher.
* changes to nmea gps and serial bringup and added rtcm netserial stream
* Contributors: Andrew Blakey, Mike Purvis
```

## kingfisher_robot

- No changes
