### PR TITLE
Use rosdistro cache to speed up buildbot reconfig

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,13 +3,13 @@
 distributions:
   hydro:
     distribution: hydro/distribution.yaml
-    distribution_cache: http://localhost/rosdistro/hydro-cache.yaml.gz
+    distribution_cache: http://packages/rosdistro/public/hydro-cache.yaml.gz
     doc_builds: [hydro/doc-build.yaml]
     release_builds: [hydro/release-build.yaml]
     source_builds: [hydro/source-build.yaml]
   indigo:
     distribution: indigo/distribution.yaml
-    distribution_cache: http://localhost/rosdistro/indigo-cache.yaml.gz
+    distribution_cache: http://packages/rosdistro/public/indigo-cache.yaml.gz
     doc_builds: [indigo/doc-build.yaml]
     release_builds: [indigo/release-build.yaml]
     source_builds: [indigo/source-build.yaml]


### PR DESCRIPTION
What it says on the tin.