### PR TITLE
jackal_firmware: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -174,7 +174,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware.git
@@ -262,6 +262,6 @@ repositories:
       type: git
       url: https://github.com/clearpathrobotics/vrpn_client_ros.git
       version: indigo-devel
-    status: maintained    
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.4-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/jackal_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.3-0`

## jackal_firmware

```
* Fixed temperature sensing.
* Fixed external e-stop support.
* Migrated logging and SM logic to common components lib.
* Contributors: Tony Baltovski
```
