### PR TITLE
firmware_components: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15,7 +15,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/firmware_components-gbp.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/firmware_components.git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `0.1.1-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/firmware_components
- release repository: git@bitbucket.org:clearpathrobotics/firmware_components-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`

## firmware_components

```
* Added IMU bias removal.
* Capitalized constants.
* Made constants public.
* Added IMU bias removal.
* Added LUT for temperature sensors.
* Add roslint dependency.
* Contributors: Mike Purvis, Tony Baltovski
```
