### PR TITLE
grizzly: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -22,6 +22,10 @@ repositories:
       version: master
     status: maintained
   grizzly:
+    doc:
+      type: git
+      url: https://github.com/g/grizzly.git
+      version: indigo-devel
     release:
       packages:
       - grizzly_description
@@ -32,7 +36,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/g/grizzly.git
+      version: indigo-devel
   grizzly_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly` to `0.3.2-0`:

- upstream repository: https://github.com/g/grizzly.git
- release repository: https://github.com/clearpath-gbp/grizzly-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.1-0`

## grizzly_description

- No changes

## grizzly_motion

```
* Added a precharge check before transitioning into MOVING state. Without this,
  precharges that take longer than 2.0 seconds will cause stuttering issues if
  there is already a cmd_vel being sent.
* Added estop check in watchdog callback for the Moving state. Without this, the
  state machine will get stuck in the Moving state if the vehicle is estopped while
  there is still a stream of motion commands being sent.
* Contributors: Mike Purvis, Peiyi Chen
```

## grizzly_msgs

```
* Add grizzly_msgs description.
* Contributors: Mike Purvis
```

## grizzly_navigation

- No changes

## grizzly_teleop

- No changes
