### PR TITLE
puma_motor_driver: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -225,6 +225,24 @@ repositories:
       url: git@bitbucket.org:clearpathrobotics/kingfisher_firmware.git
       version: indigo-devel
     status: maintained
+  puma_motor_driver:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/puma_motor_driver.git
+      version: master
+    release:
+      packages:
+      - puma_motor_driver
+      - puma_motor_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/puma_motor_driver.git
+      version: master
+    status: maintained
   ridgeback:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `puma_motor_driver` to `0.1.0-0`:

- upstream repository: https://github.com/clearpathrobotics/puma_motor_driver.git
- release repository: https://github.com/clearpath-gbp/puma_motor_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## puma_motor_driver

```
* First release of CAN/serial ROS driver for Puma.
* Contributors: Mike Purvis, Tony Baltovski
```

## puma_motor_msgs

```
* Add standalone package for a puma messages.
* Contributors: Mike Purvis, Tony Baltovski
```
