### PR TITLE
firmware_components: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15,7 +15,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/firmware_components-gbp.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/firmware_components.git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `0.2.0-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/firmware_components
- release repository: git@bitbucket.org:clearpathrobotics/firmware_components-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`

## firmware_components

```
* Improve logic which shortens logger file output.
* Retry MPU read on failure.
* PCA9685 LED controller driver.
* Split MPU hardware interface into a timed and interrupt.
* Added support for MPU-9250, renamed to MPU9X50.
* Contributors: Mike Purvis, Tony Baltovski
```
