### PR TITLE
ridgeback_firmware: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -263,6 +263,21 @@ repositories:
       url: https://github.com/ridgeback/ridgeback.git
       version: indigo-devel
     status: maintained
+  ridgeback_firmware:
+    doc:
+      type: git
+      url: git@bitbucket.org:clearpathrobotics/ridgeback_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:clearpathrobotics/ridgeback_firmware-gbp.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: git@bitbucket.org:clearpathrobotics/ridgeback_firmware.git
+      version: indigo-devel
+    status: maintained
   roboteq:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_firmware` to `0.1.0-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/ridgeback_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/ridgeback_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## ridgeback_firmware

```
* Initial release of Ridgeback firmware.
* Contributors: Mike Purvis, Tony Baltovski
```
