### PR TITLE
ridgeback_robot: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -278,6 +278,25 @@ repositories:
       url: git@bitbucket.org:clearpathrobotics/ridgeback_firmware.git
       version: indigo-devel
     status: maintained
+  ridgeback_robot:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_robot.git
+      version: indigo-devel
+    release:
+      packages:
+      - ridgeback_base
+      - ridgeback_bringup
+      - ridgeback_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_robot.git
+      version: indigo-devel
+    status: maintained
   roboteq:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.1.1-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## ridgeback_base

```
* Added lighting.
* Contributors: Tony Baltovski
```

## ridgeback_bringup

- No changes

## ridgeback_robot

- No changes
