### PR TITLE
firmware_components: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15,7 +15,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/firmware_components-gbp.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/firmware_components.git
@@ -246,7 +246,7 @@ repositories:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git
       version: indigo-devel
-    status: maintained    
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `0.3.0-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/firmware_components
- release repository: git@bitbucket.org:clearpathrobotics/firmware_components-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`

## firmware_components

```
* Add canopen libs, plus find module.
* Add FreeRTOS 7.6.0, plus C++ wrapper and find module.
* Add firmware version function.
* Contributors: Mike Purvis
```
