### PR TITLE
ridgeback_desktop: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -285,6 +285,15 @@ repositories:
       url: https://github.com/ridgeback/ridgeback.git
       version: indigo-devel
     status: maintained
+  ridgeback_desktop:
+    release:
+      packages:
+      - ridgeback_desktop
+      - ridgeback_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
+      version: 0.1.0-0
   ridgeback_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_desktop` to `0.1.0-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_desktop
- release repository: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## ridgeback_desktop

```
* Initial Ridgeback commit.
* Contributors: Tony Baltovski
```

## ridgeback_viz

```
* Initial Ridgeback commit.
* Contributors: Tony Baltovski
```
