### PR TITLE
ridgeback_firmware: 0.1.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -303,7 +303,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/ridgeback_firmware-gbp.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/ridgeback_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_firmware` to `0.1.1-2`:

- upstream repository: git@bitbucket.org:clearpathrobotics/ridgeback_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/ridgeback_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-1`

## ridgeback_firmware

```
* Improvements to power control.
* Contributors: Tony Baltovski
```
