### PR TITLE
jackal_firmware: 0.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -182,7 +182,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/jackal_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.6-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/jackal_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/jackal_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.5-0`

## jackal_firmware

```
* Added I2C Recovery Behaviour.
* Contributors: Mike Purvis, Tony Baltovski
```
