### PR TITLE
ridgeback: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -280,7 +280,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.1.3-0`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`

## ridgeback_control

```
* Updated URDF for physical changes.
* Updated control limits.
* Removed yaw estimate from robot_localization.
* Contributors: Tony Baltovski
```

## ridgeback_description

```
* Updated URDF for physical changes.
* Simulation using gazebo_ros_force_based_move.
* Contributors: Mike Purvis, Tony Baltovski
```

## ridgeback_msgs

- No changes

## ridgeback_navigation

```
* Removed CATKIN_IGNORE from ridgeback_navigation.
* ridgeback_navigation: remove deprecated footprint layer
* Simulation using gazebo_ros_force_based_move.
* Contributors: Achim Krauch, Mike Purvis, Tony Baltovski
```
