### PR TITLE
ridgeback: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -280,7 +280,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.1.4-0`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.3-0`

## ridgeback_control

- No changes

## ridgeback_description

```
* Added lms1xx as run dependency.
* Contributors: Tony Baltovski
```

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
