### PR TITLE
ridgeback_robot: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -323,7 +323,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.1.6-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.5-0`

## ridgeback_base

```
* Combined hostname and version for hardware ID.
* Fixed initialization of constant doubles.
* Added hardware ID based hostname.
* Contributors: Tony Baltovski
```

## ridgeback_bringup

```
* Specified max/min angles for Hokuyo UST-10LX.
* Added support for Hokuyo URG-10LX.
* Contributors: Tony Baltovski
```

## ridgeback_robot

- No changes
