### PR TITLE
robot_pose_ekf_gpsfix: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -329,6 +329,12 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_robot.git
       version: indigo-devel
     status: maintained
+  robot_pose_ekf_gpsfix:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:clearpathrobotics/robot_pose_ekf_gpsfix-gbp.git
+      version: 1.0.1-0
   roboteq:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_ekf_gpsfix` to `1.0.1-0`:

- upstream repository: https://bitbucket.org/clearpathrobotics/robot_pose_ekf_gpsfix.git
- release repository: git@bitbucket.org:clearpathrobotics/robot_pose_ekf_gpsfix-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
