### PR TITLE
heron_controller: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -95,6 +95,12 @@ repositories:
       url: https://github.com/heron/heron.git
       version: indigo-devel
     status: developed
+  heron_controller:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:clearpathrobotics/heron_controller-gbp.git
+      version: 0.1.0-0
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_controller` to `0.1.0-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/heron_controller.git
- release repository: git@bitbucket.org:clearpathrobotics/heron_controller-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## heron_controller

```
* Switched from updatePid to computeCommand as it is deprecated control_toolbox.
* Heron rename.
* Contributors: Tony Baltovski
```
