### PR TITLE
heron_firmware: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -101,6 +101,15 @@ repositories:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/heron_controller-gbp.git
       version: 0.1.0-0
+  heron_firmware:
+    release:
+      packages:
+      - heron_avr
+      - heron_firmware
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:clearpathrobotics/heron_firmware-gbp.git
+      version: 0.3.0-0
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_firmware` to `0.3.0-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/heron_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/heron_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## heron_avr

```
* Added user current sensing and created an estimate for power usage. Additionally, fulled out the rest of the fields of the new status message.
* Heron rename.
* Contributors: Tony Baltovski
```

## heron_firmware

```
* Heron rename.
* Contributors: Tony Baltovski
```
