### PR TITLE
declination: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - trusty
 repositories:
+  declination:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/declination.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/declination-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/declination.git
+      version: master
+    status: maintained
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `declination` to `0.0.2-0`:

- upstream repository: https://github.com/clearpathrobotics/declination
- release repository: https://github.com/clearpath-gbp/declination-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## declination

```
* Fix executable name.
```
