### PR TITLE
heron_robot: 0.1.0-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -154,7 +154,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_robot-release.git
-      version: 0.1.0-2
+      version: 0.1.0-3
     source:
       type: git
       url: https://github.com/heron/heron_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_robot` to `0.1.0-3`:

- upstream repository: https://github.com/heron/heron_robot.git
- release repository: https://github.com/clearpath-gbp/heron_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-2`

## heron_base

```
* Added Axis ptz to accessories.
* Updated nmea_topic_driver remap.
* Added env-hooks for mag and controller config.  Renamed folder kingfisher to heron.
* Added heron_base which currently only contains the base launch file and removed the many launch files in heron_bringup. Also, added accessories.launch for optional accessories.
* Contributors: Tony Baltovski
```

## heron_bringup

```
* Added Axis ptz to accessories.
* Updated nmea_topic_driver remap.
* Added lms1xx accessory and some missing run dependencies.
* Added env-hooks for mag and controller config.  Renamed folder kingfisher to heron.
* Added RTK relay from Jackal.
* Added heron_base which currently only contains the base launch file and removed the many launch files in heron_bringup. Also, added accessories.launch for optional accessories.
* Split the old heron_bring/install script into heron_bringup/install script which installs the robot_upstart job and heron_bringup/setup script which performs the configuration for udev rules as well as the ublox.
* Heron rename.
* Contributors: Tony Baltovski
```

## heron_nmea

```
* Added env-hooks for mag and controller config.  Renamed folder kingfisher to heron.
* Added dependency on heron_msgs_gencpp.  Switch to system headers and added boost to CMakeLists.txt.
* Heron rename.
* Contributors: Tony Baltovski
```

## heron_robot

```
* Added website URL.
* Heron rename.
* Contributors: Tony Baltovski
```
