### PR TITLE
heron_firmware: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -132,6 +132,10 @@ repositories:
       url: git@bitbucket.org:clearpathrobotics/heron_controller-gbp.git
       version: 0.1.0-0
   heron_firmware:
+    doc:
+      type: git
+      url: https://bitbucket.org/clearpathrobotics/heron_firmware
+      version: indigo-devel
     release:
       packages:
       - heron_avr
@@ -139,7 +143,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/heron_firmware-gbp.git
-      version: 0.3.0-0
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://bitbucket.org/clearpathrobotics/heron_firmware
+      version: indigo-devel
+    status: maintained
   heron_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_firmware` to `0.3.1-0`:

- upstream repository: git@bitbucket.org:clearpathrobotics/heron_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/heron_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.0-0`

## heron_avr

```
* Added rosbash as build dependency and fixed units on power usage.
* Added missing publisher and minor improvements.
* Contributors: Tony Baltovski
```

## heron_firmware

- No changes
