### PR TITLE
heron: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -119,7 +119,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/heron-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/heron/heron.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron` to `0.2.1-0`:

- upstream repository: https://github.com/heron/heron
- release repository: https://github.com/clearpath-gbp/heron-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.0-0`

## heron_description

```
* Updated meshes and added rear plate.
* Contributors: Tony Baltovski
```

## heron_msgs

- No changes
