### PR TITLE
ridgeback: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -372,7 +372,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.1.7-0`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.6-0`

## ridgeback_control

```
* Fixed teleop angular axis for PS4.
* Contributors: Tony Baltovski
```

## ridgeback_description

```
* Removed unused mesh.
* Uncommented RIDGEBACK_URDF_EXTRAS include.
* Contributors: Tony Baltovski
```

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
