### PR TITLE
heron_robot: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -163,7 +163,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_robot-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/heron/heron_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_robot` to `0.1.2-0`:

- upstream repository: https://github.com/heron/heron_robot.git
- release repository: https://github.com/clearpath-gbp/heron_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`

## heron_base

```
* Added tf and heron_controller as run dependency for heron_base.
* Added controller and ekf to base.launch.
* Contributors: Tony Baltovski
```

## heron_bringup

```
* Added controller and ekf to base.launch.
* Added heron_base as run dependency to heron_bringup.
* Contributors: Tony Baltovski
```

## heron_nmea

```
* Set queue_size to python publishers.
* Added navsat_sentence_relay.
* Contributors: Tony Baltovski
```

## heron_robot

- No changes
