### PR TITLE
heron_robot: 0.1.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -163,7 +163,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_robot-release.git
-      version: 0.1.4-0
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/heron/heron_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_robot` to `0.1.5-1`:

- upstream repository: https://github.com/heron/heron_robot.git
- release repository: https://github.com/clearpath-gbp/heron_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.4-0`

## heron_base

```
* Add missing install rule for heron_base configs.
* Contributors: Tony Baltovski
* Add missing install rule for heron_base configs.
* Contributors: Tony Baltovski
```

## heron_bringup

```
* Added calibrate_compass and netserial scripts in heron_bringup to be installed.
* Contributors: Tony Baltovski
* Added calibrate_compass and netserial scripts in heron_bringup to be installed.
* Contributors: Tony Baltovski
```

## heron_nmea

```
* Updated the remap for the nmea_if socket node.
* Contributors: Tony Baltovski
* Updated the remap for the nmea_if socket node.
* Contributors: Tony Baltovski
```

## heron_robot

- No changes
