### PR TITLE
jackal_robot: 0.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -294,7 +294,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.3.6-0`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.5-0`

## jackal_base

```
* Minor linter fixes to jackal_diagnostic_updater.
* Contributors: Tony Baltovski
```

## jackal_bringup

```
* Added parameter for flea3 camera frame rate.
* Added flea3 to accessories.
* Contributors: Tony Baltovski
```

## jackal_robot

- No changes
