### PR TITLE
ridgeback_robot: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -415,7 +415,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.1.7-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.6-0`

## ridgeback_base

```
* Removed GPS dependencies.
* Contributors: Johannes Meyer, Tony Baltovski
```

## ridgeback_bringup

- No changes

## ridgeback_robot

- No changes
