### PR TITLE
warthog: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -467,5 +467,24 @@ repositories:
       url: https://github.com/clearpathrobotics/vrpn_client_ros.git
       version: indigo-devel
     status: maintained
+  warthog:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog.git
+      version: indigo-devel
+    release:
+      packages:
+      - warthog_control
+      - warthog_description
+      - warthog_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog.git
+      version: indigo-devel
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.0.1-0`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## warthog_control

```
* Initial commit.
* Contributors: Tony Baltovski
```

## warthog_description

```
* Initial commit.
* Contributors: Tony Baltovski
```

## warthog_msgs

```
* Initial commit.
* Contributors: Tony Baltovski
```
