### PR TITLE
warthog_desktop: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -486,5 +486,23 @@ repositories:
       url: https://github.com/warthog-cpr/warthog.git
       version: indigo-devel
     status: developed
+  warthog_desktop:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_desktop.git
+      version: indigo-devel
+    release:
+      packages:
+      - warthog_desktop
+      - warthog_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog_desktop-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_desktop.git
+      version: indigo-devel
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_desktop` to `0.0.1-0`:

- upstream repository: https://github.com/warthog-cpr/warthog_desktop.git
- release repository: https://github.com/clearpath-gbp/warthog_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## warthog_desktop

```
* Initial commit.
* Contributors: Tony Baltovski
```

## warthog_viz

```
* Initial commit.
* Contributors: Tony Baltovski
```
