### PR TITLE
ridgeback_firmware: 0.1.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -396,7 +396,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:clearpathrobotics/ridgeback_firmware-gbp.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: git@bitbucket.org:clearpathrobotics/ridgeback_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_firmware` to `0.1.2-2`:

- upstream repository: git@bitbucket.org:clearpathrobotics/ridgeback_firmware.git
- release repository: git@bitbucket.org:clearpathrobotics/ridgeback_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.2-1`

## ridgeback_firmware

```
* Updated hardware for minor MCU changes.
* Updated I2C devices for changes in firmware_components.
* Added ARP parameters for networking.
* Removed debug logging for IMU.
* Added missing files to roslint test and fixed issues.
* Contributors: Tony Baltovski
```
