### PR TITLE
ridgeback: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -372,7 +372,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.1.9-0`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.8-0`

## ridgeback_control

```
* Updated maintainer.
* Contributors: Tony Baltovski
```

## ridgeback_description

```
* Fixed malformed stl meshes.
* Reduced gyroscopes noise.
* Reverted dimensions of chassis collision mesh to allow laser rays out.
* Added Sick S300 laser and Microstrain IMU upgrade accessories.
* Updated material properties for Ridgeback.
* Fixed IMU offset.
* Updated maintainer.
* Contributors: Tony Baltovski
```

## ridgeback_msgs

```
* Updated maintainer.
* Contributors: Tony Baltovski
```

## ridgeback_navigation

```
* Changed amcl odom model type to omni-corrected.
* Updated maintainer.
* Contributors: Tony Baltovski
```
