### PR TITLE
husky: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,33 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  husky:
+    doc:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: kinetic-devel
+    release:
+      packages:
+      - husky_base
+      - husky_bringup
+      - husky_control
+      - husky_description
+      - husky_desktop
+      - husky_gazebo
+      - husky_msgs
+      - husky_navigation
+      - husky_robot
+      - husky_simulator
+      - husky_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: kinetic-devel
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.3.0-0`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## husky_base

```
* Fix default tyre radius
* changed the tire radius in base.launch to reflect a 13 inch Husky outdoor tire
* Remove defunct email address
* Updated maintainers.
* Update bringup for multirobot
* Update URDF for multirobot
* Move packages into monorepo for kinetic; strip out ur packages
* Contributors: Martin Cote, Paul Bovbel, Tony Baltovski, Wolfgang Merkt
```

## husky_bringup

```
* Remove defunct email address
* Re-added microstrain_3dmgx2_imu as run  dependency.
* Re-added imu_transformer and um7 as run dependencies.
* Updated maintainers.
* Changed the name of robot_upstart job to ros.
* Added the UM6 as a run dep.
* Purge more UR; Implement urdf_extras
* Move packages into monorepo for kinetic; strip out ur packages
* Contributors: Paul Bovbel, Tony Baltovski
```

## husky_control

```
* Updated all package versions to 0.2.6.
* Made multimaster not come up by default in husky_control
* [husky_control] Fixed typo.
* Updated the rolling window size for more responsive control
* Fixed typo in URLs.
* Added dependency on husky_description to husky_control/package.xml
* Remove defunct email address
* Updated maintainers.
* Added more details to the config_extras workflow.
* Temp commit
* Add interface definitions
* Revert "Remove twist_mux config."
  (cherry picked from commit 4ae73877d0d3b0db8e6bc6be18f0648ea310d372)
* Update bringup for multirobot
* Purge more UR; Implement urdf_extras
* Update URDF for multirobot
* Remove twist_mux config.
* Replace twist-mux
* Contributors: Administrator, Dave Niewinski, Paul Bovbel, Peiyi Chen, TheDash, Tony Baltovski
```

## husky_description

```
* Updated all package versions to 0.2.6.
* Added a large top plate (used for waterproofing upgrade and UR5 upgrade) and an environment variable for controlling it HUSKY_LARGE_TOP_PLATE
* changed Husky wheel radius, a Husky outdoor tire is 13 inchs (0.3302m)
* [husky_description] Updated inertial parameters.
* [husky_description] Fixed depreciated syntax.
* Remove defunct email address
* Updated maintainers.
* Changes for xacro updates in kinetic.
* Add interface definitions
* Purge more UR; Implement urdf_extras
* Update URDF for multirobot
* Move packages into monorepo for kinetic; strip out ur packages
* wheel.urdf.xacro: swap iyy, izz inertias
  Fixes #34 <https://github.com/husky/husky/issues/34>.
* Contributors: Dave Niewinski, Martin Cote, Paul Bovbel, Steven Peters, Tony Baltovski
```

## husky_desktop

```
* Updated all package versions to 0.2.6.
* Fixed typo in URLs.
* Remove defunct email address
* Updated maintainers.
* Move packages into monorepo for kinetic; strip out ur packages
* Contributors: Paul Bovbel, Tony Baltovski
```

## husky_gazebo

```
* Fixed typo in URLs.
* Corrected the kinect scan topic name so it matches the laser scanner topic name.
* description.launch should be launched only once when the flag multimaster is false.
  This commit fixes #47 <https://github.com/husky/husky/issues/47>.
  Also delete the urdf subdirectory from the installation list of the package husky_gazebo
  since the directory doesn't exist.
  HOW BUILT
  $ catkin_make_isolated --install --use-ninja
  HOW VERIFIED
  $ roslaunch husky_gazebo husky_playpen.launch
  $ roslaunch husky_viz view_robot.launch
  Verify that the LiDAR is present on the gazebo husky and works as expected.
  Change-Id: I8797d561489250417dc8fe2b49d958993ca7949c
  Signed-off-by: Wei Ren <mailto:renwei@smartconn.cc>
* Remove defunct email address
* Updated maintainers.
* Temp commit
* Add interface definitions
* Update bringup for multirobot
* Purge more UR; Implement urdf_extras
* Update URDF for multirobot
* Move packages into monorepo for kinetic; strip out ur packages
* Contributors: Farzad Niroui, Paul Bovbel, Tony Baltovski, Wei Ren
```

## husky_msgs

```
* Updated all package versions to 0.2.6.
* Fixed typo in URLs.
* Remove defunct email address
* Updated maintainers.
* Contributors: Paul Bovbel, Tony Baltovski
```

## husky_navigation

```
* Updated all package versions to 0.2.6.
* Fixed typo in URLs.
* Remove defunct email address
* Updated maintainers.
* Add interface definitions
* Contributors: Paul Bovbel, Tony Baltovski
```

## husky_robot

```
* Remove defunct email address
* Updated maintainers.
* Move packages into monorepo for kinetic; strip out ur packages
* Contributors: Paul Bovbel, Tony Baltovski
```

## husky_simulator

```
* Fixed typo in URLs.
* Remove defunct email address
* Updated maintainers.
* Move packages into monorepo for kinetic; strip out ur packages
* Contributors: Paul Bovbel, Tony Baltovski
```

## husky_viz

```
* Updated all package versions to 0.2.6.
* Fixed typo in URLs.
* Remove defunct email address
* Updated maintainers.
* Update URDF for multirobot
* Move packages into monorepo for kinetic; strip out ur packages
* Contributors: Paul Bovbel, Tony Baltovski
```
