### PR TITLE
heron: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,24 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  heron:
+    doc:
+      type: git
+      url: https://github.com/heron/heron.git
+      version: kinetic-devel
+    release:
+      packages:
+      - heron_description
+      - heron_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/heron/heron.git
+      version: kinetic-devel
+    status: maintained
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron` to `0.3.0-0`:

- upstream repository: https://github.com/heron/heron
- release repository: https://github.com/clearpath-gbp/heron-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## heron_description

```
* Updated gps and imu default locations for next version of heron
* Updated stls and xacro definitions for kinetic syntax changes
* Contributors: Dave Niewinski
```

## heron_msgs

- No changes
