### PR TITLE
husky_simulator: 0.2.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -239,7 +239,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_simulator-release.git
-      version: 0.2.4-0
+      version: 0.2.7-0
     source:
       type: git
       url: https://github.com/husky/husky_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_simulator` to `0.2.7-0`:

- upstream repository: https://github.com/husky/husky_simulator.git
- release repository: https://github.com/clearpath-gbp/husky_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.4-0`

## husky_gazebo

```
* Added empty.urdf to fix vanilla husky gazebo crash
* Respect env var setup similar to husky_description
* URDF Parameters for Husky Gazebo dnt respect envvr
  Changed so the launch files follow the same convention as husky_description
* Contributors: Dave Niewinski, Devon Ash
```

## husky_simulator

- No changes
