### PR TITLE
husky_robot: 0.2.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -221,7 +221,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.2.6-0
+      version: 0.2.7-0
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.2.7-0`:

- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.6-0`

## husky_base

```
* Follow-up to #9 <https://github.com/husky/husky_robot/issues/9>, missing default value for wheel_diameter
* changed Husky tire to 13 inches (0.3302m)
* Contributors: Martin Cote, Wolfgang Merkt
```

## husky_bringup

```
* Fixes for single-ur5 husky platform so that it works in production
* Contributors: Devon Ash
```

## husky_robot

- No changes
