### PR TITLE
firmware_components: 2.9.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7,11 +7,20 @@ release_platforms:
   - xenial
 repositories:
   firmware_components:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
-      version: 2.9.2-0
+      version: 2.9.2-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git
+      version: master
+    status: maintained
   heron:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `2.9.2-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:firmware/firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.9.2-0`

## firmware_components

```
* Separating LWIP function tracing from other function tracing
* Contributors: Jeffrey Gorchynski
```
