### PR TITLE
jackal_firmware: 0.3.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -275,7 +275,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
-      version: 0.3.7-0
+      version: 0.3.8-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.8-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/jackal_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.7-0`

## jackal_firmware

```
* Consolidated udev.
* Implemented feature to report battery status on the Jackal based on total power consumed since start up.
* Contributors: Aditya Bhattacharjee, Tony Baltovski
```
