### PR TITLE
jackal_firmware: 0.3.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -87,6 +87,21 @@ repositories:
       url: https://github.com/jackal/jackal.git
       version: kinetic-devel
     status: maintained
+  jackal_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
+      version: 0.3.8-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
+      version: indigo-devel
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.8-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/jackal_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## jackal_firmware

```
* Consolidated udev.
* Implemented feature to report battery status on the Jackal based on total power consumed since start up.
* Contributors: Aditya Bhattacharjee, Tony Baltovski
```
