### PR TITLE
jackal_robot: 0.3.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -102,6 +102,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
       version: indigo-devel
     status: maintained
+  jackal_robot:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: indigo-devel
+    release:
+      packages:
+      - jackal_base
+      - jackal_bringup
+      - jackal_robot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_robot-release.git
+      version: 0.3.6-0
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: indigo-devel
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.3.6-0`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## jackal_base

```
* Minor linter fixes to jackal_diagnostic_updater.
* Contributors: Tony Baltovski
```

## jackal_bringup

```
* Added parameter for flea3 camera frame rate.
* Added flea3 to accessories.
* Contributors: Tony Baltovski
```

## jackal_robot

- No changes
