### PR TITLE
canfestival_ros: 0.8.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - trusty
 repositories:
+  canfestival_ros:
+    doc:
+      type: git
+      url: git@gitlab.clearpathrobotics.com:software/canfestival_ros.git
+      version: devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@gitlab.clearpathrobotics.com:gbp/canfestival_ros-gbp.git
+      version: 0.8.2-0
+    source:
+      type: git
+      url: git@gitlab.clearpathrobotics.com:software/canfestival_ros.git
+      version: devel
+    status: maintained
   declination:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canfestival_ros` to `0.8.2-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:software/canfestival_ros.git
- release repository: git@gitlab.clearpathrobotics.com:gbp/canfestival_ros-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## canfestival_ros

```
* CORE-7257 set socket to 0 after closing
* Contributors: Alex Bencz
```
