### PR TITLE
canfestival_ros: 0.8.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  canfestival_ros:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
+      version: devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
+      version: 0.8.4-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
+      version: devel
+    status: maintained
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canfestival_ros` to `0.8.4-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
