### PR TITLE
sevcon_ros: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -430,6 +430,24 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/roboteq-release.git
       version: 0.2.0-0
+  sevcon_ros:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - sevcon_ros
+      - sevcon_traction
+      tags:
+        release: release/indigo/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: indigo-devel
+    status: maintained
   warthog:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `0.1.0-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## sevcon_ros

```
* Renaming packages in cmakelists and package.xml
* Rename meta-package.
* Contributors: Mike O'Driscoll
```

## sevcon_traction

```
* Changed logging level.
* Changes for Warthog.
* Throttle switched.
* Move maximum torque to 100%
* Send syncs automatically at 20hz
* Launchfile update.
* Rename topics from /left/ to /left_drive/
* Renaming packages in cmakelists and package.xml
* Contributors: Mike O'Driscoll, Tony Baltovski
```
