### PR TITLE
sevcon_ros: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -154,6 +154,24 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: master
     status: maintained
+  sevcon_ros:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - sevcon_ros
+      - sevcon_traction
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: indigo-devel
+    status: maintained
   warthog:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `0.1.0-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## sevcon_ros

```
* Renaming packages in cmakelists and package.xml
* Rename meta-package.
* Contributors: Mike O'Driscoll
```

## sevcon_traction

```
* Changed logging level.
* Changes for Warthog.
* Throttle switched.
* Move maximum torque to 100%
* Send syncs automatically at 20hz
* Launchfile update.
* Rename topics from /left/ to /left_drive/
* Renaming packages in cmakelists and package.xml
* Contributors: Mike O'Driscoll, Tony Baltovski
```
