### PR TITLE
warthog_firmware: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -191,5 +191,20 @@ repositories:
       url: https://github.com/warthog-cpr/warthog.git
       version: kinetic-devel
     status: maintained
+  warthog_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_firmware` to `0.0.1-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## warthog_firmware

```
* Updates for changes to hardware
* Updated to match PCA9685 in firmware_components.
* Enabled C++11.
* Added SBUS.
* Updated the power hardware and logic.  Changed the ADCs for the new board.  Modified the lighting to work with 4 lights.
* Initial commit.
* Contributors: Tony Baltovski
```
