### PR TITLE
warthog_robot: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -500,5 +500,24 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
       version: indigo-devel
     status: maintained
+  warthog_robot:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
+      version: indigo-devel
+    release:
+      packages:
+      - warthog_base
+      - warthog_bringup
+      - warthog_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_robot` to `0.0.1-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## warthog_base

```
* Updated maintainer.
* Removed timeout feature.
* [warthog_base] Fixed dupilcate parameter name.
* [warthog_base] Fixed comment.
* [warthog_base] Updated parameter names and added timeout for not getting data from the offboard stop source.
* [warthog_base] Added optional subscriber to stop Warthog.
* [warthog_base] Updated joint names.
* Minor linter fixes.
* Diagnostics changes
* [warthog_base] Changes for updated warthog_msgs.
* Changes for Warthog that include:
  - Enabled RC control by default.
  - Added RC.
  - Added Passive joints on real robot.
  - Added diagnostics.
* Contributors: Michael Hosmar, Tony Baltovski
```

## warthog_bringup

```
* Updated maintainer.
* [warthog_bringup] Added connman blacklist config to install.
* [warthog_bringup] Added missing import.
* Added Novatel Smart6 GPS accessory.
* Changes for Warthog that include:
  - Enabled RC control by default.
  - Added RC.
  - Added Passive joints on real robot.
  - Added diagnostics.
* Contributors: Tony Baltovski
```

## warthog_robot

```
* Updated maintainer.
* Changes for Warthog that include:
  - Enabled RC control by default.
  - Added RC.
  - Added Passive joints on real robot.
  - Added diagnostics.
* Contributors: Tony Baltovski
```
