### PR TITLE
warthog_robot: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -237,7 +237,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
-      version: 0.0.1-0
+      version: 0.1.0-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_robot` to `0.1.0-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.1-0`

## warthog_base

```
* Updated bringup for systemd
* Contributors: Dave Niewinski
```

## warthog_bringup

```
* Install all necessary files
* Removed scripts dir from install
* Updated bringup for systemd
* Contributors: Dave Niewinski
```

## warthog_robot

- No changes
