### PR TITLE
ridgeback_firmware: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -154,6 +154,21 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: master
     status: maintained
+  ridgeback_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
+      version: indigo-devel
+    status: maintained
   sevcon_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_firmware` to `0.1.2-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ridgeback_firmware

```
* Updated hardware for minor MCU changes.
* Updated I2C devices for changes in firmware_components.
* Added ARP parameters for networking.
* Removed debug logging for IMU.
* Added missing files to roslint test and fixed issues.
* Contributors: Tony Baltovski
```
