### PR TITLE
ridgeback_robot: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -408,7 +408,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.1.8-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.7-0`

## ridgeback_base

```
* [ridgeback_base] Added absolute value checking for fans.
* [ridgeback_base] Fixed a typo.
* Updated maintainer.
* Fixed temperature warning for PCB and MCU temperature.
* Contributors: Tony Baltovski
```

## ridgeback_bringup

```
* Added Sick S300 laser and Microstrain IMU upgrade accessories.
* Updated maintainer.
* Contributors: Tony Baltovski
```

## ridgeback_robot

```
* Updated maintainer.
* Contributors: Tony Baltovski
```
