### PR TITLE
ridgeback_robot: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -169,6 +169,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
       version: indigo-devel
     status: maintained
+  ridgeback_robot:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ridgeback_base
+      - ridgeback_bringup
+      - ridgeback_robot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_robot.git
+      version: kinetic-devel
+    status: maintained
   sevcon_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.2.0-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ridgeback_base

```
* [ridgeback_base] Added absolute value checking for fans.
* Updated to package format 2.
* [ridgeback_base] Switched to rosserial_server_udp.
* Updated bringup for kinetic
* [ridgeback_base] Fixed a typo.
* Updated maintainer.
* Fixed temperature warning for PCB and MCU temperature.
* Contributors: Dave Niewinski, Tony Baltovski
```

## ridgeback_bringup

```
* Updated to package format 2.
* [ridgeback_base] Switched to rosserial_server_udp.
* Updated bringup for kinetic
* Added Sick S300 laser and Microstrain IMU upgrade accessories.
* Updated maintainer.
* Contributors: Dave Niewinski, Tony Baltovski
```

## ridgeback_robot

```
* Updated to package format 2.
* Updated maintainer.
* Contributors: Tony Baltovski
```
