### PR TITLE
ridgeback_firmware: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -389,7 +389,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
-      version: 0.1.2-2
+      version: 0.1.3-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_firmware` to `0.1.3-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.2-2`

## ridgeback_firmware

```
* Consolidated udev.
* Contributors: Tony Baltovski
```
