### PR TITLE
warthog_robot: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -271,7 +271,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_robot` to `0.1.2-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.1-0`

## warthog_base

```
* [warthog_base] Linter fixes.
* Updated to package format 2 and other minor CMake cleanup.
* Contributors: Tony Baltovski
```

## warthog_bringup

```
* Updated to package format 2 and other minor CMake cleanup.
* Removed un-needed install files.
* Contributors: Tony Baltovski
```

## warthog_robot

```
* Updated to package format 2 and other minor CMake cleanup.
* Contributors: Tony Baltovski
```
