### PR TITLE
grizzly_firmware: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -56,6 +56,21 @@ repositories:
       url: https://github.com/g/grizzly.git
       version: kinetic-devel
     status: maintained
+  grizzly_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/grizzly_firmware.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/grizzly_firmware-gbp.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/grizzly_firmware.git
+      version: kinetic-devel
+    status: maintained
   heron:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_firmware` to `0.3.0-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/grizzly_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/grizzly_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## grizzly_firmware

```
* Added README.md.
* Switched to polling based ADC and moved communication timeouts to network task.
* Fixed linter and applied fixes.  Consolidated udev rules and removed un-needed tests.
* Enable the brake when the MCU is asserting an estop.
* Added motor temperature monitoring to the TCU.  Also, added helper function to fill CAN RX message and removed un-used function.
* Enable the brake when the MCU is asserting an estop.
* Add the ability to the TCU to disable the TPM400 when it fails to send CAN messages.
* Added TCU system reset in fault handlers.
* Add the ability to the TCU to disable the TPM400 when it fails to send CAN messages.
* Split the linear and angular scaling for the SBUS input.
* Added the ability to reset the PID controller.
* Split the linear and angular scaling for the SBUS input.
* Updated IMU orientation.
* Fixed formatting.
* Added integral reset when passing through zero. Increased I term.
* Removed Ethernet CAN on MCU.
* Added velocity controller on TCU.
* Added MCP23008 driver for controlling indicator lights.
* Added handling of UDP messages to mcu. Removed lighting.cpp.
* Put fan and auxiliary pins into separate structs.
* Added 48v blower fan control to mcu. Fans can be controlled through the /mcu/enable_fan topic.
* Updates for ambience message.  PCA9685 controller was moved to I2C3.  Minor clean-up of unused files.
* Made upload_tcu executable.
* Updated gitignore.
* Initial changes for new hardware.
* Contributors: Aditya Bhattacharjee, Michael Hosmar, Mohamed Elshatshat, Tony Baltovski
```
