### PR TITLE
grizzly_firmware: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -65,7 +65,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/grizzly_firmware-gbp.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/grizzly_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_firmware` to `0.3.1-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/grizzly_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/grizzly_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.0-0`

## grizzly_firmware

```
* Added initial delay to enabling the PSUs.
* Contributors: Tony Baltovski
```
