### PR TITLE
grizzly_motor_driver: 0.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -83,7 +83,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly_motor_driver-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/g/grizzly_motor_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_motor_driver` to `0.0.2-1`:

- upstream repository: https://github.com/g/grizzly_motor_driver.git
- release repository: https://github.com/clearpath-gbp/grizzly_motor_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.2-0`

## grizzly_motor_driver

```
* [grizzly_motor_driver] Installed library and node.
* Contributors: Tony Baltovski
```

## grizzly_motor_msgs

- No changes
