### PR TITLE
grizzly_robot: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -102,7 +102,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly_robot-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/g/grizzly_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_robot` to `0.3.1-0`:

- upstream repository: https://github.com/g/grizzly_robot.git
- release repository: https://github.com/clearpath-gbp/grizzly_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.0-0`

## grizzly_base

- No changes

## grizzly_bringup

```
* [grizzly_bringup] Removed install for non-existent file.
* Contributors: Tony Baltovski
```

## grizzly_robot

- No changes
