### PR TITLE
flir_ptu: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -36,6 +36,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git
       version: master
     status: maintained
+  flir_ptu:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: master
+    release:
+      packages:
+      - flir_ptu_description
+      - flir_ptu_driver
+      - flir_ptu_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/flir_ptu-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: master
+    status: maintained
   grizzly:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.2.0-0`:

- upstream repository: https://github.com/ros-drivers/flir_ptu.git
- release repository: https://github.com/ros-drivers-gbp/flir_ptu-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## flir_ptu_description

```
* Add pan offset for centering joint based on calibration
* Update xacro URL to include www to not give warnings from redefinition
* Fixed spaces, fixed gazebo errors about inertia
* Revert "Fix gazebo errors"
* Updated package.xml for my maintainership
* Fix gazebo errors
* updated CMakeLists to install new meshes folder
* added mesh to visual so openrave can view it, added in transmissions
* Added transmissions and inertial elements for sim
* Reverse pan joint direction.
  Per #15 <https://github.com/ros-drivers/flir_ptu/issues/15>.
* Contributors: Allison Thackston, Dash, Devon Ash, DevonAsh, Mike Purvis, Will Baker
```

## flir_ptu_driver

```
* Linter fixes.
* Added udev rule (#39 <https://github.com/ros-drivers/flir_ptu/issues/39>)
* Added disable limits and home commands (#38 <https://github.com/ros-drivers/flir_ptu/issues/38>)
  * Adding parameters for software range limits disable
  * Adding parameters for software range limits disable
  * Added ability to disable software limits
  * Added reset subscribed topic to home PTU. This causes driver crash, so
  added respawn directive to launch file.
  * Minor edits to comply with style guide
* Add default velocity support
* Driver was crashing. Change nulls and emptys to 0s to allow typecasting to double
* added queue_size to cmd_angles (#23 <https://github.com/ros-drivers/flir_ptu/issues/23>)
* Fix linter, add sleep to blocking loop.
* Fix publish topic in cmd_angles script.
* Contributors: Allison Thackston, Ilia Baranov, Mike Purvis, TheDash, Tony Baltovski, Will Baker, dniewinski
```

## flir_ptu_viz

- No changes
