### PR TITLE
grizzly: 0.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -69,7 +69,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/g/grizzly.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly` to `0.4.1-0`:

- upstream repository: https://github.com/g/grizzly.git
- release repository: https://github.com/clearpath-gbp/grizzly-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.0-0`

## grizzly_control

- No changes

## grizzly_description

```
* Updated urdf (#21 <https://github.com/g/grizzly/issues/21>)
  * Updated urdf to have both sensor arches, all standard sensors, and some non-standard sensors
  * URDF formatting
* Contributors: dniewinski
```

## grizzly_msgs

- No changes

## grizzly_navigation

- No changes
