### PR TITLE
grizzly_robot: 0.3.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -121,7 +121,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly_robot-release.git
-      version: 0.3.5-0
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/g/grizzly_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_robot` to `0.3.5-1`:

- upstream repository: https://github.com/g/grizzly_robot.git
- release repository: https://github.com/clearpath-gbp/grizzly_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.5-0`

## grizzly_base

```
* [grizzly_base] Updated GPS indicator topic.
* Contributors: Tony Baltovski
```

## grizzly_bringup

- No changes

## grizzly_robot

- No changes
