### PR TITLE
warthog_firmware: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -494,7 +494,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_firmware` to `0.0.3-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.2-0`

## warthog_firmware

```
* Enabled the MCU CAN2.
* Contributors: Tony Baltovski
```
