### PR TITLE
husky: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -166,7 +166,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.3.1-0`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.0-0`

## husky_base

- No changes

## husky_bringup

```
* Renamed udev so it is installed
* Contributors: Dave Niewinski, Tony Baltovski
```

## husky_control

```
* Updated default controller to be PS4.  Can be set back to logitech (legacy) by setting HUSKY_LOGITECH environment variable
* Contributors: Dave Niewinski
```

## husky_description

```
* Removed unnecessary dae objects and duplicate vertices
* Contributors: Dave Niewinski
```

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

```
* Updated dependencies for robot_state_publisher
* Updated view_model.launch to include a robot_state_publisher since it was moved to control.launch
* Contributors: Dave Niewinski
```
