### PR TITLE
jackal_robot: 0.3.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -221,7 +221,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.3.7-0`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.6-0`

## jackal_base

```
* Updated the wireless interface for kinetic
* Contributors: Dave Niewinski
```

## jackal_bringup

```
* Updated default IPs for Kinetic
* Added stereo cameras accessory.
* Contributors: Dave Niewinski, Tony Baltovski
```

## jackal_robot

- No changes
