### PR TITLE
jackal: 0.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -187,7 +187,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.6.1-0`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.0-0`

## jackal_control

```
* Added missing twist_mux.yaml.  Fixed malformed meshes
* Added twist_mux and minor kinetic syntax changes
* Contributors: Dave Niewinski
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
