### PR TITLE
boxer: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,18 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  boxer:
+    release:
+      packages:
+      - boxer_control
+      - boxer_description
+      - boxer_msgs
+      - boxer_navigation
+      - boxer_visual
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: git@gitlab.clearpathrobotics.com:boxer_gbp/boxer.git
+      version: 0.0.1-0
   canfestival_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer.git
- release repository: git@gitlab.clearpathrobotics.com:boxer_gbp/boxer.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## boxer_control

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_description

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_navigation

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_visual

```
* Initial ish commit
* Contributors: Dave Niewinski
```
