### PR TITLE
boxer_simulator: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,18 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  boxer_simulator:
+    release:
+      packages:
+      - boxer_gazebo
+      - boxer_gazebo_plugins
+      - boxer_simulator
+      - cpr_plugin_tools
+      - generic_gpio_plugin
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: git@gitlab.clearpathrobotics.com:boxer_gbp/boxer_simulator.git
+      version: 0.0.1-0
   canfestival_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_simulator` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_simulator.git
- release repository: git@gitlab.clearpathrobotics.com:boxer_gbp/boxer_simulator.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## boxer_gazebo

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_gazebo_plugins

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_simulator

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## cpr_plugin_tools

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## generic_gpio_plugin

```
* Initial ish commit
* Contributors: Dave Niewinski
```
