### PR TITLE
robot_state_aggregator: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -279,6 +279,16 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_robot.git
       version: kinetic-devel
     status: maintained
+  robot_state_aggregator:
+    release:
+      packages:
+      - robot_state_aggregator
+      - robot_state_aggregator_client
+      - robot_state_aggregator_types
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: git@gitlab.clearpathrobotics.com:boxer_gbp/robot_state_aggregator.git
+      version: 0.0.1-0
   sevcon_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_aggregator` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/robot_state_aggregator.git
- release repository: git@gitlab.clearpathrobotics.com:boxer_gbp/robot_state_aggregator.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## robot_state_aggregator

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## robot_state_aggregator_client

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## robot_state_aggregator_types

```
* Initial ish commit
* Contributors: Dave Niewinski
```
