### PR TITLE
cpr_common_msgs: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -21,6 +21,17 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
       version: devel
     status: maintained
+  cpr_common_msgs:
+    release:
+      packages:
+      - cpr_common_msgs
+      - cpr_common_srvs
+      - gpio_msgs
+      - led_array_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/boxer_gbp/cpr_common_msgs.git
+      version: 0.0.1-0
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_common_msgs` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/cpr_common_msgs.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/cpr_common_msgs.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## cpr_common_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## cpr_common_srvs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## gpio_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## led_array_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```
