### PR TITLE
boxer_robot: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,16 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  boxer_robot:
+    release:
+      packages:
+      - boxer_base
+      - boxer_bringup
+      - boxer_robot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_robot.git
+      version: 0.0.1-0
   canfestival_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_robot.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_robot.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## boxer_base

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_bringup

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_robot

```
* Initial ish commit
* Contributors: Dave Niewinski
```
