### PR TITLE
boxer_desktop: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,15 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  boxer_desktop:
+    release:
+      packages:
+      - boxer_desktop
+      - boxer_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_desktop.git
+      version: 0.0.1-0
   canfestival_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_desktop` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_desktop.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_desktop.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## boxer_desktop

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_viz

```
* Initial ish commit
* Contributors: Dave Niewinski
```
