### PR TITLE
visual_indication: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -297,6 +297,12 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
       version: indigo-devel
     status: maintained
+  visual_indication:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/boxer_gbp/visual_indication.git
+      version: 0.0.1-0
   warthog:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visual_indication` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/visual_indication.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/visual_indication.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## visual_indication

```
* Initial ish commit
* Contributors: Dave Niewinski
```
