### PR TITLE
boxer_firmware: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,12 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  boxer_firmware:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_firmware.git
+      version: 0.0.1-0
   canfestival_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_firmware` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_firmware.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## boxer_firmware

```
* Initial ish commit
* Contributors: Dave Niewinski
```
