### PR TITLE
boxer: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7,6 +7,10 @@ release_platforms:
   - xenial
 repositories:
   boxer:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/boxer.git
+      version: master
     release:
       packages:
       - boxer_control
@@ -17,6 +21,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/boxer.git
+      version: master
+    status: maintained
   boxer_desktop:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## boxer_control

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_description

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_navigation

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_visual

```
* Initial ish commit
* Contributors: Dave Niewinski
```
