### PR TITLE
boxer_desktop: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -18,6 +18,10 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer.git
   boxer_desktop:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/boxer_desktop.git
+      version: master
     release:
       packages:
       - boxer_desktop
@@ -25,6 +29,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_desktop.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/boxer_desktop.git
+      version: master
+    status: maintained
   boxer_firmware:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_desktop` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_desktop.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_desktop.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## boxer_desktop

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_viz

```
* Initial ish commit
* Contributors: Dave Niewinski
```
