### PR TITLE
boxer_robot: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -61,6 +61,10 @@ repositories:
       version: master
     status: maintained
   boxer_robot:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/boxer_robot.git
+      version: master
     release:
       packages:
       - boxer_base
@@ -69,6 +73,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_robot.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/boxer_robot.git
+      version: master
+    status: maintained
   boxer_simulator:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_robot.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_robot.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## boxer_base

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_bringup

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_robot

```
* Initial ish commit
* Contributors: Dave Niewinski
```
