### PR TITLE
boxer_simulator: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -80,6 +80,10 @@ repositories:
       version: master
     status: maintained
   boxer_simulator:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/boxer_simulator.git
+      version: master
     release:
       packages:
       - boxer_gazebo
@@ -91,6 +95,11 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_simulator.git
       version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/boxer_simulator.git
+      version: master
+    status: maintained
   canfestival_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_simulator` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_simulator.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_simulator.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.1-0`

## boxer_gazebo

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_gazebo_plugins

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## boxer_simulator

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## cpr_plugin_tools

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## generic_gpio_plugin

```
* Initial ish commit
* Contributors: Dave Niewinski
```
