### PR TITLE
robot_state_aggregator: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -376,6 +376,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   robot_state_aggregator:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/robot_state_aggregator.git
+      version: master
     release:
       packages:
       - robot_state_aggregator
@@ -385,6 +389,11 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/robot_state_aggregator.git
       version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/robot_state_aggregator.git
+      version: master
+    status: maintained
   sevcon_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_aggregator` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/robot_state_aggregator.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/robot_state_aggregator.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.1-0`

## robot_state_aggregator

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## robot_state_aggregator_client

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## robot_state_aggregator_types

```
* Initial ish commit
* Contributors: Dave Niewinski
```
