### PR TITLE
linux_gpio_driver: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -341,6 +341,21 @@ repositories:
       url: https://github.com/jackal/jackal_robot.git
       version: indigo-devel
     status: maintained
+  linux_gpio_driver:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/linux_gpio_driver.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/boxer_gbp/linux_gpio_driver.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/linux_gpio_driver.git
+      version: master
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_gpio_driver` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/linux_gpio_driver.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/linux_gpio_driver.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## linux_gpio_driver

```
* Initial ish commit
* Contributors: Dave Niewinski
```
