### PR TITLE
jackal_robot: 0.3.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -335,7 +335,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.3.7-0
+      version: 0.3.8-0
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.3.8-0`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.3.7-0`

## jackal_base

```
* [jackal_base] Added environment variable for changing the wireless interface which controlls the light on the HMI.
* [jackal_base] Fixed linting.
* Contributors: Tony Baltovski
```

## jackal_bringup

- No changes

## jackal_robot

- No changes
