### PR TITLE
boxer_simulator: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -94,7 +94,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_simulator.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/Boxer/boxer_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_simulator` to `0.0.6-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_simulator.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_simulator.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.0.5-0`

## boxer_gazebo

```
* Cleaned up launches, model colours, and camera location
* Contributors: Dave Niewinski
```

## boxer_gazebo_plugins

- No changes

## boxer_simulator

- No changes

## cpr_plugin_tools

- No changes

## generic_gpio_plugin

- No changes
