### PR TITLE
jackal_firmware: 0.3.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -290,7 +290,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
-      version: 0.3.8-0
+      version: 0.3.9-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.9-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/jackal_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.3.8-0`

## jackal_firmware

```
* Simple battery status light based on voltage
* Updated the udev rule to an actually tested one
* Updated udev rule for jackal mcu to avoid conflict with microstrain
* Contributors: Dave Niewinski, David Niewinski
```
