### PR TITLE
valence_bms: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -445,6 +445,20 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
       version: indigo-devel
     status: maintained
+  valence_bms:
+    release:
+      packages:
+      - valence_bms_driver
+      - valence_bms_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/valence_bms.git
+      version: kinetic-devel
+    status: developed
   visual_indication:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `valence_bms` to `0.0.1-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/valence_bms.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## valence_bms_driver

```
* [valence_bms_driver] Fixed linter error.
* [valence_bms_driver] Added MultiModule publishing.
* [valence_bms_driver] Added args to example launch file.
* Added roslaunch and roslint tests.
* Initial commit.
* Contributors: Tony Baltovski
```

## valence_bms_msgs

```
* [valence_bms_driver] Added MultiModule publishing.
* [valence_bms_msgs] Updated ModuleInfo.
* Initial commit.
* Contributors: Tony Baltovski
```
