### PR TITLE
valence_bms: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -453,7 +453,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/valence_bms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `valence_bms` to `0.0.2-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/valence_bms.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.1-0`

## valence_bms_driver

```
* Updated license and installed files.
* Contributors: Tony Baltovski
```

## valence_bms_msgs

```
* Updated license and installed files.
* Contributors: Tony Baltovski
```
