### PR TITLE
firmware_components: 2.9.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -60,7 +60,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
-      version: 2.9.3-0
+      version: 2.9.3-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `2.9.3-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.9.3-0`

## firmware_components

```
* [pca9685] Fixed bug with lighting enable reference passing.
* Contributors: Tony Baltovski
```
