### PR TITLE
boxer: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -21,7 +21,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/Boxer/boxer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer` to `0.0.6-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.5-0`

## boxer_control

```
* Pulled well back on teleop until PS4 bug is fixed.
* Added extra config layer to control
* Contributors: Dave Niewinski
```

## boxer_description

- No changes

## boxer_msgs

- No changes

## boxer_navigation

- No changes

## boxer_visual

- No changes
