### PR TITLE
microhard_snmp: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -356,6 +356,12 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/Boxer/linux_gpio_driver.git
       version: master
     status: maintained
+  microhard_snmp:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: git@gitlab.clearpathrobotics.com:gbp/microhard_snmp-gbp.git
+      version: 0.0.1-0
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microhard_snmp` to `0.0.1-0`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/microhard_snmp.git
- release repository: git@gitlab.clearpathrobotics.com:gbp/microhard_snmp-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## microhard_snmp

```
* Initial Release
* Contributors: Michael Hosmar, Shrey Kavi
```
