### PR TITLE
Fix microhard_snmp url

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -360,7 +360,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: git@gitlab.clearpathrobotics.com:gbp/microhard_snmp-gbp.git
+      url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
       version: 0.0.1-0
   puma_motor_driver:
     doc:


### PR DESCRIPTION
Jenkins doesn't work with ssh release urls.