### PR TITLE
heron_desktop: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -259,6 +259,24 @@ repositories:
       url: https://github.com/heron/heron.git
       version: kinetic-devel
     status: maintained
+  heron_desktop:
+    doc:
+      type: git
+      url: https://github.com/heron/heron_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - heron_desktop
+      - heron_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron_desktop-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/heron/heron_desktop.git
+      version: kinetic-devel
+    status: maintained
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_desktop` to `0.0.3-0`:

- upstream repository: https://github.com/heron/heron_desktop.git
- release repository: https://github.com/clearpath-gbp/heron_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## heron_desktop

- No changes

## heron_viz

```
* Merge pull request #1 <https://github.com/heron/heron_desktop/issues/1> from ssubramaniam-cpr/kinetic-devel
  Changed interactive marker topic update
* Changed interative marker topic update
* Contributors: Shreya Subramaniam, Tony Baltovski
```
