### PR TITLE
ridgeback: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -398,6 +398,26 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: master
     status: maintained
+  ridgeback:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ridgeback_control
+      - ridgeback_description
+      - ridgeback_msgs
+      - ridgeback_navigation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: kinetic-devel
+    status: maintained
   ridgeback_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.2.2-0`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ridgeback_control

```
* Changed boost::shared_ptr to urdfdom shared pointers
* ridgeback_control: fixed missing calculation of wheels_k_ (regression from daa4bc9050f786ed092fab911dd217da6febeae0)
* Simplify boolean logic for wheel separation checks
* Allow URDF to be optional
* Contributors: Catherine Wong, Chad Rockey, Johannes Meyer, Tony Baltovski
```

## ridgeback_description

- No changes

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
