### PR TITLE
cpr_gps_navigation: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -135,6 +135,19 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/Boxer/cpr_common_msgs.git
       version: master
     status: maintained
+  cpr_gps_navigation:
+    release:
+      packages:
+      - cpr_gps_localization
+      - cpr_gps_navigation
+      - cpr_gps_navigation_client
+      - cpr_gps_navigation_msgs
+      - cpr_gps_navigation_server
+      - cpr_gps_safety
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp
+      version: 0.1.1-1
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cpr_gps_localization

- No changes

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_msgs

- No changes

## cpr_gps_navigation_server

- No changes

## cpr_gps_safety

- No changes
