### PR TITLE
jackal_robot: 0.3.9-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -367,7 +367,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.3.8-0
+      version: 0.3.9-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.3.9-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.8-0`

## jackal_base

```
* [jackal_base] Minor launch file nit.
* Merge pull request #14 <https://github.com/jackal/jackal_robot/issues/14> from hawesie/kinetic-devel
  Add parameter to change IMU message type.
* Add paramter to change IMU message type.
* Contributors: Nick Hawes, Tony Baltovski
```

## jackal_bringup

```
* Temporarily removed point grey driver dependency
* Contributors: Dave Niewinski
```

## jackal_robot

- No changes
