### PR TITLE
jackal_robot: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -309,7 +309,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.3.6-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.4.0-0`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.3.6-0`

## jackal_base

```
* [jackal_base] Fixed linting.
* Contributors: Tony Baltovski
```

## jackal_bringup

```
* Temporarily removed point grey driver dependency
* Merge pull request #10 <https://github.com/jackal/jackal_robot/issues/10> from jackal/stereo-cameras
  Added stereo cameras accessory.
* Added stereo cameras accessory.
* Contributors: Dave Niewinski, Tony Baltovski
```

## jackal_robot

- No changes
