### PR TITLE
cpr_gps_common: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -135,6 +135,23 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/Boxer/cpr_common_msgs.git
       version: master
     status: maintained
+  cpr_gps_common:
+    release:
+      packages:
+      - autonomy_msgs
+      - autonomy_msgs_utils
+      - cpr_diagnostics
+      - cpr_estop_monitor
+      - cpr_gps_common
+      - cpr_gps_navigation_msgs
+      - cpr_pointcloud_filter
+      - cpr_std_srvs
+      - nav_core_cpr
+      - nav_utils
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
+      version: 0.1.1-1
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## autonomy_msgs

- No changes

## autonomy_msgs_utils

- No changes

## cpr_diagnostics

- No changes

## cpr_estop_monitor

- No changes

## cpr_gps_common

- No changes

## cpr_gps_navigation_msgs

- No changes

## cpr_pointcloud_filter

- No changes

## cpr_std_srvs

- No changes

## nav_core_cpr

- No changes

## nav_utils

- No changes
