### PR TITLE
cpr_gps_common: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -151,7 +151,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
-      version: 0.1.1-1
+      version: 0.1.2-0
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.2-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.1-1`

## autonomy_msgs

```
* restart and revert changes
* Contributors: Ebrahim
```

## autonomy_msgs_utils

```
* restart and revert changes
* Contributors: Ebrahim
```

## cpr_diagnostics

```
* restart and revert changes
* Contributors: Ebrahim
```

## cpr_estop_monitor

```
* roslint dependency for estop_monitor
* Contributors: Ebrahim
* restart and revert changes
* Contributors: Ebrahim
```

## cpr_gps_common

```
* restart and revert changes
* nav_utils
* Contributors: Ebrahim
```

## cpr_gps_navigation_msgs

```
* restart and revert changes
* Contributors: Ebrahim
```

## cpr_pointcloud_filter

```
* restart and revert changes
* Contributors: Ebrahim
```

## cpr_std_srvs

```
* restart and revert changes
* Contributors: Ebrahim
```

## nav_core_cpr

```
* restart and revert changes
* Contributors: Ebrahim
```

## nav_utils

```
* restart and revert changes
* Contributors: Ebrahim
```
