### PR TITLE
gps_mpc_navigation: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -167,6 +167,19 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git
       version: master
     status: maintained
+  gps_mpc_navigation:
+    release:
+      packages:
+      - cpr_local_planner
+      - cpr_nav_core_adapter
+      - cpr_pathtracker
+      - gps_mpc_navigation
+      - grid_library
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
+      version: 0.1.1-0
+    status: maintained
   grizzly:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.1.1-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/gps_mpc_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## cpr_local_planner

```
* deps for bloom
* prepare for release and versions
* Merge branch 'dev' into 'master'
* Merge branch 'dependency_fix' into 'dev'
  Dependency fix
  See merge request research/gps_mpc_navigation!10
* Acado dep and warnings
* change structure of the folder to bloom and remove extra packages
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_nav_core_adapter

```
* prepare for release and versions
* package dependency
* Merge branch 'dev' into 'master'
* local navigation goal check
* goal tolerance params
* path_frame_id remove
* change structure of the folder to bloom and remove extra packages
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_pathtracker

```
* deps for bloom
* prepare for release and versions
* Merge branch 'dev' into 'master'
* Merge branch 'dependency_fix' into 'dev'
  Dependency fix
  See merge request research/gps_mpc_navigation!10
* remove set acado_dir line
* Acado dep and warnings
* resolve circular dependencies to cpr_docking+install acado from deb
* local goal
* local navigation goal check
* goal tolerance params
* Merge branch 'autonomous_docking' into 'dev'
  Autonomous docking
  See merge request eshahrivar/gps_mpc_navigation!9
* Merge branch 'odom_loc_fix' into 'autonomous_docking'
  Odom loc fix
  See merge request eshahrivar/gps_mpc_navigation!8
* change goal tolerance in localmode
* read lookahead params from parameter server
* change min_lookahead and tolerance for localmode
* lint
* call inflation radius service
* change speed in local mode
* remove autonomy msgs dependency, included in cpr_docking
* Merge branch 'dev' into 'master'
  Dev
  See merge request eshahrivar/gps_mpc_navigation!7
* Merge branch 'installable_repo' into 'dev'
  changed CMAKE files to install into install folder
  See merge request eshahrivar/gps_mpc_navigation!6
* changed CMAKE files to install into install folder
* localenabled localization
* Merge branch 'dev_adapter' into 'dev'
  Dev adapter
  See merge request eshahrivar/gps_mpc_navigation!4
* replanning mpc
* Merge branch 'dev_adapter_localMode' into 'dev_adapter'
  increase speed of the robot in mpc lib
  See merge request eshahrivar/gps_mpc_navigation!3
* increase speed of the robot in mpc lib
* Merge branch 'dev_adapter_localMode' into 'dev_adapter'
  Dev adapter local mode
  See merge request eshahrivar/gps_mpc_navigation!2
* load frame ids from private node
* taget mode activated to track in map frame
* removed nav_core_state object
* loading footprints
* debugging the footprint set
* loading manager and sending the goal
* initializing objects in cpr_adapter
* debugging prints
* trying to fix initialization
* goal_tolerance_
* goal tolerance
* loading the mpc
* adapter
* remove unused files
* cpr_local_planner+open source base_local_planner
* back to the otto base_local_planner package
* added nav_core_cpr and updated base_local_planner and path tracker accordingly
* remove move_base and msgs
* removed path caching and costmap_plugin dependencies
* remove cpr_spatial and feature_manager dependency
* removed dependencies
* remove dependencies on grid library and sbpl
* fixed cmake
* trimming collision files
* remove unused members of cpr_base_local_planner
* disabled replanning always
* removed diagnostic reporter
* remove diagnostic reporter
* removed cpr_diagnostic handler from vehicle control
* remove tracker diagnostics from cpr_mpc_planner
* allow_replan=false all the time
* disabled replanning
* removed feature_manager in cpr_base_local_planner
* remove extra stuff
* build_able
* removed platoon
* Initial commit
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## gps_mpc_navigation

```
* Merge branch 'dev' into 'master'
  Dev
  See merge request research/gps_mpc_navigation!12
* Merge branch 'bloom_restructuring' into 'dev'
* bloom restructuring
* meta package
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## grid_library

```
* prepare for release and versions
* Merge branch 'dev' into 'master'
* change structure of the folder to bloom and remove extra packages
* build_able
* Initial commit
* Contributors: Ebrahim, Ebrahim Shahrivar
```
