### PR TITLE
cpr_gps_navigation: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -152,6 +152,20 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
       version: 0.1.2-0
+  cpr_gps_navigation:
+    release:
+      packages:
+      - cpr_gps_localization
+      - cpr_gps_navigation
+      - cpr_gps_navigation_client
+      - cpr_gps_navigation_server
+      - cpr_gps_safety
+      - cpr_gps_tasks
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
+      version: 0.1.1-0
+    status: maintained
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.1-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## cpr_gps_localization

- No changes

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

- No changes

## cpr_gps_safety

- No changes

## cpr_gps_tasks

- No changes
