### PR TITLE
firmware_components: 2.9.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -175,7 +175,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
-      version: 2.9.3-1
+      version: 2.9.4-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `2.9.4-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.9.3-1`

## firmware_components

```
* Removed error count reset preventing i2c bus reinit
* Contributors: lazzalini
```
