### PR TITLE
cpr_gps_navigation: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -164,7 +164,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     status: maintained
   firmware_components:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.3-0`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.2-0`

## cpr_gps_localization

```
* Merge branch 'naked_repo' into 'master'
  removing params and launch files
  See merge request research/cpr_gps_navigation!29
* removing params and launch files
* laser filter
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

```
* Merge branch 'naked_repo' into 'master'
  removing params and launch files
  See merge request research/cpr_gps_navigation!29
* removing params and launch files
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_navigation_server

```
* Merge branch 'naked_repo' into 'master'
  removing params and launch files
  See merge request research/cpr_gps_navigation!29
* removing params and launch files
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_safety

- No changes

## cpr_gps_tasks

- No changes
