### PR TITLE
boxer_robot: 0.0.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -73,7 +73,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_robot.git
-      version: 0.0.7-1
+      version: 0.0.8-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/Boxer/boxer_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.0.8-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer_robot.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_robot.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.7-1`

## boxer_base

- No changes

## boxer_bringup

```
* Setup upstart job to run as root
* Contributors: Dave Niewinski
```

## boxer_robot

- No changes
