### PR TITLE
boxer: 0.0.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -21,7 +21,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer.git
-      version: 0.0.7-0
+      version: 0.0.8-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/Boxer/boxer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer` to `0.0.8-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/boxer.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.7-0`

## boxer_control

- No changes

## boxer_description

```
* Updated robot name in urdf
* Contributors: Dave Niewinski
```

## boxer_msgs

- No changes

## boxer_navigation

- No changes

## boxer_visual

- No changes
