### PR TITLE
firmware_components: 2.9.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6,6 +6,12 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  firmware_components:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
+      version: 2.9.4-1
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `2.9.4-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## firmware_components

```
* Removed error count reset preventing i2c bus reinit
* Contributors: lazzalini
```
