### PR TITLE
jackal_firmware: 0.3.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -39,5 +39,20 @@ repositories:
       url: https://github.com/husky/husky.git
       version: melodic-devel
     status: maintained
+  jackal_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
+      version: 0.3.9-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.9-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/jackal_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jackal_firmware

```
* Simple battery status light based on voltage
* Updated the udev rule to an actually tested one
* Updated udev rule for jackal mcu to avoid conflict with microstrain
* Contributors: Dave Niewinski, David Niewinski
```
