### PR TITLE
ridgeback_firmware: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -54,5 +54,20 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
       version: indigo-devel
     status: maintained
+  ridgeback_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
+      version: 0.1.4-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_firmware` to `0.1.4-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ridgeback_firmware

```
* Fixed bug in passing lighting_enable by reference.
* Contributors: Tony Baltovski
```
