### PR TITLE
warthog_firmware: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -69,5 +69,20 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
       version: indigo-devel
     status: maintained
+  warthog_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_firmware` to `0.0.3-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## warthog_firmware

```
* Enabled the MCU CAN2.
* Contributors: Tony Baltovski
```
