### PR TITLE
jackal_robot: 0.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -54,6 +54,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
       version: indigo-devel
     status: maintained
+  jackal_robot:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - jackal_base
+      - jackal_bringup
+      - jackal_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_robot-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: kinetic-devel
+    status: maintained
   ridgeback_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.5.0-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
