### PR TITLE
puma_motor_driver: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -418,7 +418,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
-      version: 0.1.1-2
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/puma_motor_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `puma_motor_driver` to `0.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/puma_motor_driver.git
- release repository: https://github.com/clearpath-gbp/puma_motor_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-2`

## puma_motor_driver

```
* Package format 2, dependency fix.
* Contributors: Mike Purvis
```

## puma_motor_msgs

```
* Package format 2.
* Contributors: Mike Purvis
```
