### PR TITLE
puma_motor_driver: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -85,7 +85,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/puma_motor_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `puma_motor_driver` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/puma_motor_driver.git
- release repository: https://github.com/clearpath-gbp/puma_motor_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-1`

## puma_motor_driver

```
* Renamed verifying 16x16 raw bytes and added verfying 8x8 function. Added parentheses to evaluate AND before comparison and added default case to switch statement in non-void function. Also, minor linter fixes.
* Updated fixed-point conversion.
* Contributors: Tony Baltovski
```

## puma_motor_msgs

- No changes
