### PR TITLE
firmware_components: 2.9.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7,11 +7,20 @@ release_platforms:
   - bionic
 repositories:
   firmware_components:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
-      version: 2.9.4-1
+      version: 2.9.5-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git
+      version: master
+    status: maintained
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `2.9.5-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.9.4-1`

## firmware_components

- No changes
