### PR TITLE
puma_motor_driver: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -94,7 +94,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/puma_motor_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `puma_motor_driver` to `0.2.1-1`:

- upstream repository: https://github.com/clearpathrobotics/puma_motor_driver.git
- release repository: https://github.com/clearpath-gbp/puma_motor_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.0-1`

## puma_motor_driver

```
* [puma_motor_driver] Disabld checking of message if it was a status cause it was causing issues.
* Contributors: Tony Baltovski
```

## puma_motor_msgs

- No changes
