### PR TITLE
ridgeback_robot: 0.2.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -472,7 +472,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.2.3-0
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.2.4-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.3-0`

## ridgeback_base

```
* Merge pull request #26 <https://github.com/ridgeback/ridgeback_robot/issues/26> from ridgeback/RPSW-119
  Added the ability to disable using the MCU
* [ridgeback_base] Added param type for use_mcu.
* [ridgeback_base] Added lighting and cooling under use_mcu flag.
* [ridgeback_base] Added envar for using MCU.
* Contributors: Tony Baltovski
```

## ridgeback_bringup

- No changes

## ridgeback_robot

- No changes
