### PR TITLE
ridgeback_robot: 0.2.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -115,6 +115,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
       version: indigo-devel
     status: maintained
+  ridgeback_robot:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ridgeback_base
+      - ridgeback_bringup
+      - ridgeback_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
+      version: 0.2.4-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_robot.git
+      version: kinetic-devel
+    status: maintained
   warthog_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.2.4-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ridgeback_base

```
* Merge pull request #26 <https://github.com/ridgeback/ridgeback_robot/issues/26> from ridgeback/RPSW-119
  Added the ability to disable using the MCU
* [ridgeback_base] Added param type for use_mcu.
* [ridgeback_base] Added lighting and cooling under use_mcu flag.
* [ridgeback_base] Added envar for using MCU.
* Contributors: Tony Baltovski
```

## ridgeback_bringup

- No changes

## ridgeback_robot

- No changes
