### PR TITLE
valence_bms: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -134,6 +134,24 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_robot.git
       version: kinetic-devel
     status: maintained
+  valence_bms:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/valence_bms.git
+      version: kinetic-devel
+    release:
+      packages:
+      - valence_bms_driver
+      - valence_bms_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/valence_bms.git
+      version: kinetic-devel
+    status: maintained
   warthog_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `valence_bms` to `0.0.2-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/valence_bms.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## valence_bms_driver

```
* Updated license and installed files.
* Contributors: Tony Baltovski
```

## valence_bms_msgs

```
* Updated license and installed files.
* Contributors: Tony Baltovski
```
