### PR TITLE
moose_desktop: 0.1.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -425,6 +425,24 @@ repositories:
       url: https://github.com/moose-cpr/moose.git
       version: master
     status: maintained
+  moose_desktop:
+    doc:
+      type: git
+      url: https://github.com/moose-cpr/moose_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - moose_desktop
+      - moose_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/moose_desktop-release.git
+      version: 0.1.0-3
+    source:
+      type: git
+      url: https://github.com/moose-cpr/moose_desktop.git
+      version: kinetic-devel
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_desktop` to `0.1.0-3`:

- upstream repository: https://github.com/moose-cpr/moose_desktop.git
- release repository: https://github.com/clearpath-gbp/moose_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## moose_desktop

```
* Initial commit
* Contributors: Tony Baltovski
```

## moose_viz

```
* Initial commit
* Contributors: Tony Baltovski
```
