### PR TITLE
moose_firmware: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -443,6 +443,21 @@ repositories:
       url: https://github.com/moose-cpr/moose_desktop.git
       version: kinetic-devel
     status: maintained
+  moose_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_firmware.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/moose_firmware-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_firmware.git
+      version: master
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_firmware` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/moose_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/moose_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## moose_firmware

```
* Updated generator start logic.
* Initial commit
* Contributors: Tony Baltovski
```
