### PR TITLE
moose_robot: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -476,6 +476,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/moose_motor_driver.git
       version: master
     status: maintained
+  moose_robot:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_robot.git
+      version: master
+    release:
+      packages:
+      - moose_base
+      - moose_bringup
+      - moose_robot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/moose_robot-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_robot.git
+      version: master
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_robot` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/moose_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/moose_robot-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## moose_base

```
* Merge branch 'diagnostics_agg' into 'master'
  Added diagnostics_agg
  See merge request research/moose_robot!1
* Added diagnostics_agg
* [moose_base] Added bms driver to base launch.
* Fixed valence_bms_driver dependency.
* [moose_base] Fixed linter errors.
* Initial work for moose.
* Contributors: Dave Niewinski, David Niewinski, Tony Baltovski
```

## moose_bringup

```
* Fixed valence_bms_driver dependency.
* Initial work for moose.
* Contributors: Tony Baltovski
```

## moose_robot

```
* Initial work for moose.
* Contributors: Tony Baltovski
```
