### PR TITLE
moose_robot: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -489,7 +489,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/moose_robot-gbp.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/moose_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_robot` to `0.1.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/moose_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/moose_robot-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.0-1`

## moose_base

```
* [moose_base] Updated dependencies.
* Contributors: Tony Baltovski
```

## moose_bringup

- No changes

## moose_robot

- No changes
