### PR TITLE
moose_simulator: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -507,7 +507,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/moose_simulator-release.git
-      version: 0.1.0-2
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/moose-cpr/moose_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_simulator` to `0.1.1-1`:

- upstream repository: https://github.com/moose-cpr/moose_simulator.git
- release repository: https://github.com/clearpath-gbp/moose_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.0-2`

## moose_gazebo

```
* [moose_gazebo] Updated dependencies.
* Contributors: Tony Baltovski
```

## moose_simulator

- No changes
