### PR TITLE
heron: 0.3.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -279,7 +279,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron-release.git
-      version: 0.3.1-0
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/heron/heron.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron` to `0.3.2-1`:

- upstream repository: https://github.com/heron/heron
- release repository: https://github.com/clearpath-gbp/heron-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.1-0`

## heron_control

```
* [heron_control] Fixing missing dep and minor clean-up.
* Contributors: Tony Baltovski
```

## heron_description

```
* Changed mesh declarations to use packages instead of xacro finds (#8 <https://github.com/heron/heron/issues/8>)
* Contributors: Dave Niewinski
```

## heron_msgs

- No changes
