### PR TITLE
jackal_firmware: 0.3.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -360,7 +360,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
-      version: 0.3.10-1
+      version: 0.3.11-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.3.11-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/jackal_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.10-1`

## jackal_firmware

```
* Merge branch 'rpsw-173' into 'indigo-devel'
  Fix NMEA sentence termination bug
  See merge request research/jackal_firmware!30
* Fix NMEA sentence termination bug
* Contributors: Chris Iverach-Brereton, David Niewinski
```
