### PR TITLE
husky_cartographer_navigation: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -48,6 +48,21 @@ repositories:
       url: https://github.com/husky/husky.git
       version: melodic-devel
     status: maintained
+  husky_cartographer_navigation:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_cartographer_navigation.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_cartographer_navigation-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/husky/husky_cartographer_navigation.git
+      version: melodic-devel
+    status: developed
   jackal_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_cartographer_navigation` to `0.0.1-1`:

- upstream repository: https://github.com/husky/husky_cartographer_navigation.git
- release repository: https://github.com/clearpath-gbp/husky_cartographer_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## husky_cartographer_navigation

```
* Updated maintainer.
* Removed rviz to use husky_viz.
* minor change to install instructions
* removed unused file
* added cartographer_ros as run depend
* updated install instructions
* Added brief Cartographer description and generated image
* Update CMakeLists.txt to install custom RViz config
* Modified install script to clone repos based on ros distro
* Slight tuning
* Update README.md
* Fix install script
* Added config and launch files to use Cartographer on the Husky
* Contributors: Aditya Bhattacharjee, Tony Baltovski, ljazzal
```
