### PR TITLE
husky_cartographer_navigation: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -57,7 +57,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_cartographer_navigation-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/husky/husky_cartographer_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_cartographer_navigation` to `0.0.2-1`:

- upstream repository: https://github.com/husky/husky_cartographer_navigation.git
- release repository: https://github.com/clearpath-gbp/husky_cartographer_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.0.1-1`

## husky_cartographer_navigation

```
* Updated to package.xml format 2.
* Added husky_navigation as run dep.
* Contributors: Tony Baltovski
```
