### PR TITLE
ridgeback: 0.2.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -545,7 +545,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.2.2-0
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.2.3-1`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.2.2-0`

## ridgeback_control

```
* Fix controller odom bug, it works well in multi robots case now
* Contributors: yizheng
```

## ridgeback_description

```
* [ridgeback_description] Removing namespace arg.
* Add namespace to gazebo plugin, it works well in multi robots case now
* Contributors: Tony Baltovski, yizheng
```

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
