### PR TITLE
ridgeback: 0.2.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -130,6 +130,26 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: master
     status: maintained
+  ridgeback:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ridgeback_control
+      - ridgeback_description
+      - ridgeback_msgs
+      - ridgeback_navigation
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback-release.git
+      version: 0.2.3-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: kinetic-devel
+    status: maintained
   ridgeback_cartographer_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.2.3-1`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ridgeback_control

```
* Fix controller odom bug, it works well in multi robots case now
* Contributors: yizheng
```

## ridgeback_description

```
* [ridgeback_description] Removing namespace arg.
* Add namespace to gazebo plugin, it works well in multi robots case now
* Contributors: Tony Baltovski, yizheng
```

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
