### PR TITLE
husky: 0.4.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -42,7 +42,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.4.3-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.4.2-1`

## husky_base

- No changes

## husky_bringup

```
* Add the other product ID for the PS4 controller to the udev rule
* Update the udev rules to map the controllers to appropriate symlinks instead of relying on device enumeration to save us
* Contributors: Chris I-B
```

## husky_control

```
* Update the udev rules to map the controllers to appropriate symlinks instead of relying on device enumeration to save us
* Remove the device override for the PS4 controller since we pair with bluez now (which maps the device to /dev/input/js0)
* Fix the filename in the launch fike
* Make the Logitech controller config file explicit. Add ascii-art controllers to label the axes to make configuration easier
* Contributors: Chris I-B, Chris Iverach-Brereton
```

## husky_description

```
* Fixed GazeboRosControlPlugin missing error
* Contributors: lerolynn
```

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

```
* [husky_viz] Removed joint_state_publisher since joint_state_publisher_gui is generating the same data.
* Fix a deprecation warning about the joint state publisher's gui
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```
