### PR TITLE
jackal_robot: 0.5.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -379,7 +379,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.5.0-0
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.5.1-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.5.0-0`

## jackal_base

```
* [jackal_base] Stopped using Vector3 messages for on-board IMU.
* Merge pull request #17 <https://github.com/jackal/jackal_robot/issues/17> from ms-iot/init_windows
  Support Jackal ROS packages on Windows
* Merge branch 'init_windows' of https://github.com/ms-iot/jackal_robot into init_windows
* Folding Wifi into single function
* removed extra code.
* specify jackal serial port as arg in launch file (#7 <https://github.com/jackal/jackal_robot/issues/7>)
* allow configuring jackal's port in env (#6 <https://github.com/jackal/jackal_robot/issues/6>)
* fix calibration script (#5 <https://github.com/jackal/jackal_robot/issues/5>)
  * fix batch file
  * fix batch script for mix use of forward slash
  * remove todo comment
* check wireless connection on Windows (#4 <https://github.com/jackal/jackal_robot/issues/4>)
  * check wireless connection on Windows
  * add comment about unused member variable
* add calibrate_compass.bat (#3 <https://github.com/jackal/jackal_robot/issues/3>)
* add env-hook (#2 <https://github.com/jackal/jackal_robot/issues/2>)
* Merge pull request #1 <https://github.com/jackal/jackal_robot/issues/1> from seanyen/init_windows
  Remove to-be-ported code path to unblock the Windows build.
* quickly get around the build break.
* Contributors: James Xu, Lou Amadio, Sean Yen, Tony Baltovski, seanyen
```

## jackal_bringup

```
* Merge pull request #18 <https://github.com/jackal/jackal_robot/issues/18> from jackal/melodic-testing-fixes
  Small fixes revealed in testing on live hardware
* Fix the IP address for the urg_node used by the hokuyo lidar
* Add the additional udev rule for the PS4 controller
* [jackal_bringup] Re-added pointgrey_camera_driver as run depend.
* Add udev rules for the PS4, logitech, and USB to serial adapter (copied from Husky)
* Add the urg_node to the dependencies
* Create the urg_node needed for the hokuyo sensor
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## jackal_robot

- No changes
