### PR TITLE
cpr_gps_navigation: 0.1.8-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -159,12 +159,13 @@ repositories:
       - cpr_gps_navigation
       - cpr_gps_navigation_client
       - cpr_gps_navigation_server
+      - cpr_gps_path_smoothing
       - cpr_gps_safety
       - cpr_gps_tasks
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.7-1
+      version: 0.1.8-2
     status: maintained
   firmware_components:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.8-2`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.7-1`

## cpr_gps_localization

```
* Merge branch 'parallel_planner' into 'master'
  Parallel planner
* Contributors: Ebrahim, Ebrahim Shahrivar, Jose Mastrangelo
```

## cpr_gps_navigation

```
* Merge branch 'parallel_planner' into 'master'
  Parallel planner
* path smoothing server
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_navigation_client

```
* Merge branch 'parallel_planner' into 'master'
  Parallel planner
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_navigation_server

```
* Merge branch 'parallel_planner' into 'master'
  Parallel planner
* Contributors: Ebrahim, Ebrahim Shahrivar, Jose Mastrangelo
```

## cpr_gps_path_smoothing

```
* changelog
* Merge branch 'parallel_planner' into 'master'
  Parallel planner
* omplapp
* path smoothing server
* Contributors: Ebrahim, Ebrahim Shahrivar
* path smoothing server
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_safety

```
* Merge branch 'parallel_planner' into 'master'
  Parallel planner
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_tasks

- No changes
