### PR TITLE
gps_mpc_navigation: 0.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -193,7 +193,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
-      version: 0.1.2-0
+      version: 0.1.3-1
     status: maintained
   grizzly:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.1.3-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/gps_mpc_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.2-0`

## cpr_local_planner

- No changes

## cpr_nav_core_adapter

```
* Merge branch 'turning_radius' into 'master'
* Contributors: Ebrahim Shahrivar, Jose Mastrangelo, José Mastrangelo
```

## cpr_pathtracker

```
* Merge branch 'turning_radius' into 'master'
* Contributors: Ebrahim, Ebrahim Shahrivar, Jose Mastrangelo, José Mastrangelo
```

## gps_mpc_navigation

- No changes

## grid_library

- No changes
