### PR TITLE
cpr_gps_navigation: 0.1.9-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -165,7 +165,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.8-2
+      version: 0.1.9-1
     status: maintained
   firmware_components:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.9-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.8-2`

## cpr_gps_localization

- No changes

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

```
* Merge branch 'devel' into 'master'
* Contributors: Ebrahim, Ebrahim Shahrivar, Jose Mastrangelo
```

## cpr_gps_path_smoothing

```
* Contributors: Ebrahim
```

## cpr_gps_safety

- No changes

## cpr_gps_tasks

- No changes
