### PR TITLE
canfestival_ros: 0.9.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  canfestival_ros:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
+      version: 0.9.1-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
+      version: devel
+    status: maintained
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canfestival_ros` to `0.9.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## canfestival_ros

```
* CORE-16627 Aborted CAN traffic does not resume communication
  In rare occasions where CAN SDO traffic failed to be sent, the original code was silently ignoring the failure.
  This change introduces a pending state for requests that gets flipped to in progress when the request is succesfully sent.
  If the request is not successfully sent, the state does not change (stays pending) and the request will be retried at a later time based on the next request to be sent.
  Also, the failure to sent the request is logged as a warning.
* Contributors: Guillaume Autran, Mike Purvis
```
