### PR TITLE
sevcon_ros: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -235,6 +235,24 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_robot.git
       version: kinetic-devel
     status: maintained
+  sevcon_ros:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - sevcon_ros
+      - sevcon_traction
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: indigo-devel
+    status: maintained
   valence_bms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## sevcon_ros

```
* Renaming packages in cmakelists and package.xml
* Rename meta-package.
* Contributors: Mike O'Driscoll
```

## sevcon_traction

```
* Changed logging level.
* Changes for Warthog.
* Throttle switched.
* Move maximum torque to 100%
* Send syncs automatically at 20hz
* Launchfile update.
* Rename topics from /left/ to /left_drive/
* Renaming packages in cmakelists and package.xml
* Contributors: Mike O'Driscoll, Tony Baltovski
```
