### PR TITLE
warthog_firmware: 0.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -698,7 +698,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
-      version: 0.0.3-0
+      version: 0.0.4-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_firmware` to `0.0.4-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.3-0`

## warthog_firmware

```
* Apply fixes from Jackal to compile for Bionic/Melodic
* Contributors: Chris Iverach-Brereton
```
