### PR TITLE
cpr_gps_navigation: 0.1.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -165,7 +165,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.10-1
+      version: 0.1.11-1
     status: maintained
   firmware_components:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.11-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.10-1`

## cpr_gps_localization

```
* Merge branch 'devel' into 'master'
  Devel
  See merge request gps-navigation/cpr_gps_navigation!53
  See merge request gps-navigation/cpr_gps_navigation!52
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_navigation

```
* Contributors: Ebrahim Shahrivar
```

## cpr_gps_navigation_client

```
* See merge request gps-navigation/cpr_gps_navigation!52
* Contributors: Ebrahim Shahrivar
```

## cpr_gps_navigation_server

```
* Contributors: Ebrahim, Ebrahim Shahrivar, Jose Mastrangelo, José Mastrangelo
```

## cpr_gps_path_smoothing

```
* Merge branch 'devel' into 'master'
* See merge request gps-navigation/cpr_gps_navigation!52
* Contributors: Ebrahim Shahrivar, Jose Mastrangelo
```

## cpr_gps_safety

```
* See merge request gps-navigation/cpr_gps_navigation!54
* Update safety_monitor.py
  See merge request gps-navigation/cpr_gps_navigation!52
* Contributors: Ebrahim, Ebrahim Shahrivar, Jose Mastrangelo, José Mastrangelo
```

## cpr_gps_tasks

```
* See merge request gps-navigation/cpr_gps_navigation!52
* Contributors: Ebrahim Shahrivar
```
