### PR TITLE
gps_mpc_navigation: 0.1.4-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -193,7 +193,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
-      version: 0.1.3-1
+      version: 0.1.4-2
     status: maintained
   grizzly:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.1.4-2`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/gps_mpc_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.3-1`

## cpr_local_planner

```
* See merge request gps-navigation/gps_mpc_navigation!18
* Contributors: Ebrahim Shahrivar
```

## cpr_nav_core_adapter

```
* See merge request gps-navigation/gps_mpc_navigation!18
* Contributors: Ebrahim Shahrivar
```

## cpr_pathtracker

```
* Contributors: Ebrahim, Ebrahim Shahrivar, Jose Mastrangelo, José Mastrangelo
```

## gps_mpc_navigation

```
* See merge request gps-navigation/gps_mpc_navigation!18
* Contributors: Ebrahim Shahrivar
```

## grid_library

```
* See merge request gps-navigation/gps_mpc_navigation!18
* Contributors: Ebrahim Shahrivar
```
