### PR TITLE
dingo_simulator: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -41,6 +41,24 @@ repositories:
       url: https://github.com/dingo-cpr/dingo.git
       version: master
     status: developed
+  dingo_simulator:
+    doc:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_simulator.git
+      version: master
+    release:
+      packages:
+      - dingo_gazebo
+      - dingo_simulator
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/dingo_simulator-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_simulator.git
+      version: master
+    status: developed
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_simulator` to `0.1.0-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_simulator.git
- release repository: https://github.com/clearpath-gbp/dingo_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dingo_gazebo

```
* Revert to using dirname; i blanked on the conversation where we went over the new standards
* Add the empty world launch file (useful for replaying bags w/o obstacles getting in the way)
* Add spawn_dingo.launch for compatibility with the new simulation environments. Enable teleop by default in the simulations. Use $(find ...) instead of $(dirname) for improved compatibility with external packages
* Unified launch files, added platform specific gains and updated dependencies.
* [dingo_gazebo] Removed media.
* Initial commit for handoff to tbaltovski; still some updates required
* Contributors: Chris Iverach-Brereton, Jason Higgins, Tony Baltovski
```

## dingo_simulator

```
* Unified launch files, added platform specific gains and updated dependencies.
* Initial commit for handoff to tbaltovski; still some updates required
* Contributors: Jason Higgins, Tony Baltovski
```
