### PR TITLE
boxer_robot: 0.0.10-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -73,7 +73,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_robot.git
-      version: 0.0.9-1
+      version: 0.0.10-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/Boxer/boxer_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.0.10-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/Boxer/boxer_robot.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/boxer_robot.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.9-1`

## boxer_base

```
* Updated camera framerates for hardware limitations
* Put parentheses around the print statements
* Contributors: Chris I-B, Dave Niewinski
```

## boxer_bringup

- No changes

## boxer_robot

- No changes
