### PR TITLE
jackal: 0.6.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -346,7 +346,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.6.5-2
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.6.6-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.6.5-2`

## jackal_control

```
* Disable ekf option (#71 <https://github.com/jackal/jackal/issues/71>)
  * added env var and if-statement to disable robot ekf
  * changed if to unless
  * clearer wording
* Contributors: jmastrangelo-cpr
```

## jackal_description

- No changes

## jackal_msgs

- No changes

## jackal_navigation

```
* Remove the leading / from the gmapping default scan topic
* Expose the scan_topic and use_map_topic parameters in the demo launch files
* Contributors: Chris Iverach-Brereton
```
