### PR TITLE
moose_motor_driver: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -204,6 +204,24 @@ repositories:
       url: https://github.com/jackal/jackal_robot.git
       version: kinetic-devel
     status: maintained
+  moose_motor_driver:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_motor_driver.git
+      version: master
+    release:
+      packages:
+      - moose_motor_driver
+      - moose_motor_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/moose_motor_driver-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_motor_driver.git
+      version: master
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_motor_driver` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/moose_motor_driver.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/moose_motor_driver-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## moose_motor_driver

```
* [moose_motor_driver] minor linting.
* Added fault detection.
* Initial commit
* Contributors: Tony Baltovski
```

## moose_motor_msgs

```
* Added fault detection.
* Initial commit
* Contributors: Tony Baltovski
```
