### PR TITLE
moose: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -204,6 +204,25 @@ repositories:
       url: https://github.com/jackal/jackal_robot.git
       version: kinetic-devel
     status: maintained
+  moose:
+    doc:
+      type: git
+      url: https://github.com/moose-cpr/moose.git
+      version: master
+    release:
+      packages:
+      - moose_control
+      - moose_description
+      - moose_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/moose-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/moose-cpr/moose.git
+      version: master
+    status: maintained
   moose_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose` to `0.1.0-1`:

- upstream repository: https://github.com/moose-cpr/moose.git
- release repository: https://github.com/clearpath-gbp/moose-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## moose_control

```
* Updated collisions,
* Made the generator optional
* Moved interactive markers to manned control and removed joy
* Added wheels to URDF.
* Initial commit for Moose.
* Contributors: Dave Niewinski, Tony Baltovski
```

## moose_description

```
* Updated collisions,
* Made the generator optional
* Moved interactive markers to manned control and removed joy
* Added wheels to URDF.
* Initial commit for Moose.
* Contributors: Dave Niewinski, Tony Baltovski
```

## moose_msgs

```
* Initial commit for Moose.
* Contributors: Tony Baltovski
```
