### PR TITLE
moose_firmware: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -223,6 +223,21 @@ repositories:
       url: https://github.com/moose-cpr/moose.git
       version: master
     status: maintained
+  moose_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_firmware.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/moose_firmware-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_firmware.git
+      version: master
+    status: maintained
   moose_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_firmware` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/moose_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/moose_firmware-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## moose_firmware

```
* Updated generator start logic.
* Initial commit
* Contributors: Tony Baltovski
```
