### PR TITLE
moose_robot: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -256,6 +256,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/moose_motor_driver.git
       version: master
     status: maintained
+  moose_robot:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_robot.git
+      version: master
+    release:
+      packages:
+      - moose_base
+      - moose_bringup
+      - moose_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/moose_robot-gbp.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/moose_robot.git
+      version: master
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_robot` to `0.1.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/moose_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/moose_robot-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## moose_base

```
* [moose_base] Updated dependencies.
* Contributors: Tony Baltovski
```

## moose_bringup

- No changes

## moose_robot

- No changes
