### PR TITLE
vanguard_bms: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -417,6 +417,21 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/valence_bms.git
       version: kinetic-devel
     status: maintained
+  vanguard_bms:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/vanguard_bms.git
+      version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/vanguard_bms-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/vanguard_bms.git
+      version: main
+    status: maintained
   warthog:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vanguard_bms` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/vanguard_bms.git
- release repository: https://github.com/clearpath-gbp/vanguard_bms-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## vanguard_bms

```
* Added candump of BMS.
* Minor rework getting warnings and errors.
* Initial work.
* Initial commit
* Contributors: Tony Baltovski
```
