### PR TITLE
ridgeback_robot: 0.2.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -375,7 +375,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.2.5-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.4-1`

## ridgeback_base

```
* Use eval + find to properly load the default mag config file
* Added RIDGEBACK_MAG_CONFIG to madgwick filter and set a default optenv
* Removed env-hooks
* Contributors: Chris Iverach-Brereton, Dave Niewinski
```

## ridgeback_bringup

- No changes

## ridgeback_robot

- No changes
