### PR TITLE
ridgeback_robot: 0.2.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -598,7 +598,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.2.6-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.5-1`

## ridgeback_base

```
* Bump CMake version to avoid CMP0048 warning.
* [ridgeback_base] Fixed missing forward slash.
* Contributors: Tony Baltovski
```

## ridgeback_bringup

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## ridgeback_robot

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```
