### PR TITLE
puma_motor_driver: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -306,7 +306,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/puma_motor_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `puma_motor_driver` to `0.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/puma_motor_driver.git
- release repository: https://github.com/clearpath-gbp/puma_motor_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.1-1`

## puma_motor_driver

```
* [puma_motor_driver] Improved logging.
* [puma_motor_driver] Added settings for socketcan interface.
* [puma_motor_driver] Fixes for roslint.
* [puma_motor_driver] Switched to socketcan_interface, updated configuration and added extra field handling.
* [puma_motor_driver] Removed serial gateway.
* [puma_motor_driver] Update for cpp11.
* Contributors: Tony Baltovski
```

## puma_motor_msgs

- No changes
