### PR TITLE
cpr_gps_common: 0.1.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -151,7 +151,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
-      version: 0.1.5-1
+      version: 0.1.6-1
   cpr_gps_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.6-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.5-1`

## autonomy_msgs

- No changes

## autonomy_msgs_utils

- No changes

## cpr_diagnostics

- No changes

## cpr_estop_monitor

- No changes

## cpr_gps_common

- No changes

## cpr_gps_navigation_msgs

```
* Merge branch 'master' into 'melodic'
* Contributors: Ebrahim Shahrivar, Michael Hosmar, Mike Hosmar
```

## cpr_pointcloud_filter

```
* Merge branch 'melodic' into 'master'
* Contributors: Ebrahim, Ebrahim Shahrivar, ebrahim
```

## cpr_std_srvs

- No changes

## nav_core_cpr

```
* Contributors: Ebrahim, Ebrahim Shahrivar, ebrahim
```

## nav_utils

- No changes
