### PR TITLE
cpr_gps_common: 0.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -21,6 +21,23 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
       version: devel
     status: maintained
+  cpr_gps_common:
+    release:
+      packages:
+      - autonomy_msgs
+      - autonomy_msgs_utils
+      - cpr_diagnostics
+      - cpr_estop_monitor
+      - cpr_gps_common
+      - cpr_gps_navigation_msgs
+      - cpr_pointcloud_filter
+      - cpr_std_srvs
+      - nav_core_cpr
+      - nav_utils
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
+      version: 0.1.6-1
   dingo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.6-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## autonomy_msgs

- No changes

## autonomy_msgs_utils

- No changes

## cpr_diagnostics

- No changes

## cpr_estop_monitor

- No changes

## cpr_gps_common

- No changes

## cpr_gps_navigation_msgs

```
* Merge branch 'master' into 'melodic'
* Contributors: Ebrahim Shahrivar, Michael Hosmar, Mike Hosmar
```

## cpr_pointcloud_filter

```
* Merge branch 'melodic' into 'master'
* Contributors: Ebrahim, Ebrahim Shahrivar, ebrahim
```

## cpr_std_srvs

- No changes

## nav_core_cpr

```
* Contributors: Ebrahim, Ebrahim Shahrivar, ebrahim
```

## nav_utils

- No changes
