### PR TITLE
ridgeback_robot: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -392,7 +392,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.2.5-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.3.0-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.5-1`

## ridgeback_base

```
* [ridgeback_base] Added dependency.
* [ridgeback_base] Updated to use new functions from puma_motor_drivers.
* [ridgeback_base] Used ros::ok() for while condition on thread loops.
* Updates for C++11.
* Contributors: Tony Baltovski
```

## ridgeback_bringup

```
* [ridgeback_bringup] Increased CAN TX queue size.
* Contributors: Tony Baltovski
```

## ridgeback_robot

- No changes
