### PR TITLE
gps_mpc_navigation: 0.1.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -186,14 +186,13 @@ repositories:
     release:
       packages:
       - cpr_local_planner
-      - cpr_nav_core_adapter
       - cpr_pathtracker
       - gps_mpc_navigation
       - grid_library
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
-      version: 0.1.4-2
+      version: 0.1.6-1
     status: maintained
   grizzly:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.1.6-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/gps_mpc_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.4-2`

## cpr_local_planner

- No changes

## cpr_pathtracker

- No changes

## gps_mpc_navigation

```
* remove cpr_nav_core_adapter
* Contributors: Ebrahim
```

## grid_library

- No changes
