### PR TITLE
gps_mpc_navigation: 0.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -109,6 +109,17 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/firmware/firmware_components.git
       version: master
     status: maintained
+  gps_mpc_navigation:
+    release:
+      packages:
+      - cpr_local_planner
+      - cpr_pathtracker
+      - gps_mpc_navigation
+      - grid_library
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
+      version: 0.1.6-1
   heron:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.1.6-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/gps_mpc_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cpr_local_planner

- No changes

## cpr_pathtracker

- No changes

## gps_mpc_navigation

```
* remove cpr_nav_core_adapter
* Contributors: Ebrahim
```

## grid_library

- No changes
