### PR TITLE
earth_rover_piksi: 1.8.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -94,6 +94,25 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_simulator.git
       version: master
     status: developed
+  earth_rover_piksi:
+    doc:
+      type: git
+      url: https://github.com/earthrover/earth_rover_piksi.git
+      version: master
+    release:
+      packages:
+      - earth_rover_piksi
+      - piksi_multi_rtk
+      - piksi_rtk_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/earth_rover_piksi-release.git
+      version: 1.8.2-1
+    source:
+      type: git
+      url: https://github.com/earthrover/earth_rover_piksi.git
+      version: master
+    status: maintained
   firmware_components:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `earth_rover_piksi` to `1.8.2-1`:

- upstream repository: https://github.com/earthrover/earth_rover_piksi.git
- release repository: https://github.com/clearpath-gbp/earth_rover_piksi-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
