### PR TITLE
dingo_robot: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -76,6 +76,25 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_desktop.git
       version: master
     status: maintained
+  dingo_robot:
+    doc:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_robot.git
+      version: melodic-devel
+    release:
+      packages:
+      - dingo_base
+      - dingo_bringup
+      - dingo_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/dingo_robot-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_robot.git
+      version: melodic-devel
+    status: developed
   dingo_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.1.0-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## dingo_base

```
* Bump CMake version to avoid CMP0048 warning.
* [dingo_base] Reduced log spamming.
* [dingo_base] Fixed not using function for ros::ok().
* [dingo_base] Updated encoder count for mmp-s14 motor config.
* [dingo_base] Added motor parameters as rosparams to be loaded as a YAML which is set by an enviroment variable.
* [dingo_base] Updated I gain.
* Merge branch 'melodic-devel' of gitlab.clearpathrobotics.com:dingo/dingo_robot into melodic-devel
* Merge branch 'tb-rework' into 'melodic-devel'
  Initial rework
  See merge request dingo/dingo_robot!2
* [dingo_base] roslint fixes.
* [dingo_base] Fixed mag_config_default.yaml location.
* [dingo_base] Updated mag config params.
* [dingo_base] Moved network logger before rosserial server.
* [dingo_base] Updated logger to use ROS based logging for its own logging.
* [dingo_base] Updated CAN IDs and directions for joints.
* [dingo_base] Added missing join for logger thread.
* [dingo_base] Flipped motor signs.
* [dinog_hardware] Fixed typo.
* [dingo_base] Added network based logger.
* [dingo_lighting] Updated drive lighting patterns.
* [dingo_hardware] Reduced logging by throttling.
* [dingo_hardware] Updated motor parameters.
* [dingo_base] Reworkd Dingo model selection.
* Swapped dependency location since it is used by dingo_bringup and not dingo_base.
* Unified dingo launch files.  Also, removed connman file in install.
* Merge branch 'jh-melodic-devel' into 'melodic-devel'
  Initial Dingo robot implementation; not yet tested on real board
  See merge request dingo/dingo_robot!1
* Initial Dingo robot implementation; not yet tested on real board
* Contributors: Chris Iverach-Brereton, Jason Higgins, Tony Baltovski
```

## dingo_bringup

```
* Bump CMake version to avoid CMP0048 warning.
* [dingo_bringup] Increased CAN TX queue size.
* Merge pull request #1 <https://github.com/dingo-cpr/dingo_robot/issues/1> from dingo-cpr/rs-l515-update
  Remove the work-around for the RealSense L515 pointcloud data
* Remove the work-around for the RealSense L515 pointcloud data; the driver's been updated and this is no longer needed.
* [dingo_bringup] Added missing export.
* Merge branch 'no-realsense-to-laser' into 'melodic-devel'
  Remove the realsense's depthimage-to-laserscan node
  See merge request dingo/dingo_robot!4
* Remove the realsense's depthimage-to-laserscan node; the realsense is not well-suited to use as a lidar, so just remove this
* Move the depthimage to laserscan node inside the right group
* Merge branch 'melodic-devel' of gitlab.clearpathrobotics.com:dingo/dingo_robot into melodic-devel
* Add the missing enable_infra flag that's necessary to get the L515 to publish data correctly
* Merge branch 'tb-rework' into 'melodic-devel'
  Initial rework
  See merge request dingo/dingo_robot!2
* [dingo_bringup] Symlinked launch files.
* [dingo_bringup] Update instrall script and made it executable.
* [dingo_bringup] Set dingo_bringup as executable.
* [dingo_bringup] Maded script executable.
* Swapped dependency location since it is used by dingo_bringup and not dingo_base.
* [dingo_bringup] Added script to set environment variable for dingo-o
* Unified dingo launch files.  Also, removed connman file in install.
* Merge branch 'cib-accessories' into 'melodic-devel'
  Enable Hokuyo Lidar & Realsense in dingo_bringup
  See merge request dingo/dingo_robot!3
* Enable Hokuyo Lidar & Realsense in dingo_bringup
* Merge branch 'jh-melodic-devel' into 'melodic-devel'
  Initial Dingo robot implementation; not yet tested on real board
  See merge request dingo/dingo_robot!1
* Initial Dingo robot implementation; not yet tested on real board
* Contributors: Chris Iverach-Brereton, Jason Higgins, Tony Baltovski
```

## dingo_robot

```
* Bump CMake version to avoid CMP0048 warning.
* [dingo_robot] Removed dependency on dingo_firmware for now.
* Merge branch 'jh-melodic-devel' into 'melodic-devel'
  Initial Dingo robot implementation; not yet tested on real board
  See merge request dingo/dingo_robot!1
* Initial Dingo robot implementation; not yet tested on real board
* Contributors: Jason Higgins, Tony Baltovski
```
