### PR TITLE
launch_delay: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -403,6 +403,21 @@ repositories:
       url: https://github.com/jackal/jackal_robot.git
       version: indigo-devel
     status: maintained
+  launch_delay:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/launch_delay.git
+      version: main
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/launch_delay-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/launch_delay.git
+      version: main
+    status: maintained
   linux_gpio_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_delay` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/launch_delay.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/launch_delay-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## launch_delay

```
* Fixed README to augment job rather then replace.
* Minor changes to release this.
* README.md edited online with Bitbucket
* README.md edited online with Bitbucket
* README.md edited online with Bitbucket
* Made script executable.
* package.xml created online with Bitbucket
* CMakeLists.txt created online with Bitbucket
* launch_delay.sh created online with Bitbucket
* delayed_launch.launch created online with Bitbucket
* Initial commit with README.md
* Contributors: Jeff Schmidt, Tony Baltovski, jeff-o
```
