### PR TITLE
cpr_gps_navigation: 0.1.14-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -51,7 +51,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.14-1
+      version: 0.1.14-2
   dingo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.14-2`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.14-1`

## cpr_gps_localization

- No changes

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

```
* yaml-cpp dependency
* Contributors: Ebrahim
```

## cpr_gps_navigation_server

- No changes

## cpr_gps_path_smoothing

- No changes

## cpr_gps_safety

- No changes

## cpr_gps_tasks

- No changes
