### PR TITLE
dingo_robot: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -103,7 +103,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.1.1-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.0-1`

## dingo_base

```
* Added missing test dependencies.
* Roslint fixes
* Diagnostics update (#2 <https://github.com/dingo-cpr/dingo_robot/issues/2>)
  * Separate the diagnostics config into 3 separate files (common, omni, diff)
  * Tidy up the wheel expectations, add the wi-fi connected topic to general
  * Fix the CAN IDs of the four wheels
  * Fix c&p error with left/right in the previous commit
  * Correctly load the diff/omni files in the right places
  * Remove the wi-fi connected entry
  * Refactor the diagnostic updater to remove magic numbers & move them to defined constants. Add a message to the power diagnostics to get rid of an error saying no message was set
  * Use constexpr instead of define
  * Fill in the correct voltage & amperage warning levels from Dana.  Move the definitions into a new header so we can re-use it in lighting.cpp.  Add a new over-volt lighting state with all-blue lights
  * Start implementing Li battery checks using the BatteryState message. Topic subscribed-to needs checking, as do the percentage warning levels
  * Update the battery state topic
  * Remove the leading / from the battery topics to stay consistent with mcu/status
  * Add an extra TODO indicator for the Lithium battery testing as a blanket warning that it's untested so far
  * Roslint fixes
  * Increase the low-battery warning to 20% for Lithium batteries
  * Increase the critical battery level to 10% for lithium batteries
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## dingo_bringup

```
* Added missing test dependencies.
* Contributors: Tony Baltovski
```

## dingo_robot

- No changes
