### PR TITLE
dingo: 0.1.6-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -66,7 +66,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.6-1
+      version: 0.1.6-2
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.6-2`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.6-1`

## dingo_control

```
* [dingo_control] Increased acceleration limit for omnidirectional platform.
* Contributors: Tony Baltovski
```

## dingo_description

- No changes

## dingo_msgs

- No changes

## dingo_navigation

- No changes
