### PR TITLE
cpr_gps_common: 0.1.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -37,7 +37,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
-      version: 0.1.6-1
+      version: 0.1.7-1
   cpr_gps_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.7-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.6-1`

## autonomy_msgs

- No changes

## autonomy_msgs_utils

- No changes

## cpr_diagnostics

- No changes

## cpr_estop_monitor

- No changes

## cpr_gps_common

- No changes

## cpr_gps_navigation_msgs

- No changes

## cpr_pointcloud_filter

- No changes

## cpr_std_srvs

- No changes

## nav_core_cpr

```
* Merge branch 'tolerance_from_action' into 'master'
  tolerance from action for isGoalReached
  See merge request gps-navigation/cpr_gps_common!8
* tolerance from action for isGoalReached
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## nav_utils

- No changes
