### PR TITLE
cpr_gps_navigation: 0.1.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -51,7 +51,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.16-2
+      version: 0.1.17-1
   dingo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.17-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.16-2`

## cpr_gps_localization

```
* Merge branch 'nextviapoint_fix' into 'master'
* created node to converted data in sensor NED frame to ENU frame
* Contributors: Ebrahim Shahrivar, Jose Mastrangelo
```

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

```
* Merge branch 'nextviapoint_fix' into 'master'
  Nextviapoint fix
  See merge request gps-navigation/cpr_gps_navigation!65
* Update mission_server.cpp
* remove unsued param
* fix racing between parallel planner and makePlan path shifting
* parallel planner viapoint update
* tolerance adpater
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## cpr_gps_path_smoothing

- No changes

## cpr_gps_safety

```
* Merge branch 'safety_pause' into 'master'
* Contributors: Ebrahim, Jose Mastrangelo, José Mastrangelo
```

## cpr_gps_tasks

- No changes
