### PR TITLE
gps_mpc_navigation: 0.1.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -171,7 +171,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
-      version: 0.1.6-1
+      version: 0.1.7-1
   heron:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.1.7-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/gps_mpc_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.6-1`

## cpr_local_planner

- No changes

## cpr_pathtracker

```
* Merge branch 'tolerance_from_action' into 'master'
* Contributors: Ebrahim, Ebrahim Shahrivar
```

## gps_mpc_navigation

- No changes

## grid_library

- No changes
