### PR TITLE
um7: 0.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12,5 +12,11 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/serial-release.git
       version: 1.2.1-1
+  um7:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um7-release.git
+      version: 0.0.6-1
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `um7` to `0.0.6-1`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## um7

```
* Fix error of mag topic not publish
* Contributors: Nicolas SIMON
```
