### PR TITLE
um6: 1.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12,6 +12,12 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/serial-release.git
       version: 1.2.1-1
+  um6:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um6-release.git
+      version: 1.1.3-1
   um7:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `um6` to `1.1.3-1`:

- upstream repository: https://github.com/ros-drivers/um6.git
- release repository: https://github.com/ros-drivers-gbp/um6-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## um6

```
* Disabled using MagneticField message by default.
* Updated to be able to use MagneticField message.
* Updated TravisCI to use Industrial CI for Kinetic and Melodic.
* Contributors: Tony Baltovski
```
