### PR TITLE
ros_mscl: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -637,6 +637,21 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/Boxer/robot_state_aggregator.git
       version: master
     status: maintained
+  ros_mscl:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/ros_mscl.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ros_mscl-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/ros_mscl.git
+      version: master
+    status: maintained
   sevcon_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: https://github.com/clearpath-gbp/ros_mscl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## ros_mscl

```
* Move the libmscl dependency to a normal depend, as it's required for both building & running
* Remove the examples folder, move the ros_mscl contents into the root of the repo. Update the package data to remove the broken dependency (until we can get it fixed). Update authors & maintainer for this fork.
* Fixed bug preventing device report service from working on a GQ7.
* Added support for raw binary file output and RTK status message (see changelog for details)
* Added PPS Source, GPIO Config, and external GPS time updating
* Added feature checking for filter reset and imu category
* Fixed driver error that tried to publish magnetometer data when it is not present
* Added device Idle prior to shutdown to play nice across host power cycles
  
  Fixed flags used to determine valid time for GNSS time message
* Fixed time reference output to use ROS time for header timestamp
* sensor_msgs::TimeReference added per user request
* Added a resume command at the end of device setup as the GQ7 needs it.
* Changed GQ7 filter init alignment selector to a bitfield in the example launch file
  
  Fixed quaternion sensor2vehicle frame rotation (negated the indices instead of the values by accident)
* See changelog for full details.
  Added support for GQ7
  Changed "GPS" topic to "GNSS1" and added "GNSS2"
  Refactored code
* Added Device Settings service:  Supports function selectors: 3 (Save), 4 (Load Saved), 5 (Load Defaults)
* Added nav filter heading state feedback
* Only doing device_status_callback() at 1 Hz now
* Fully filled-out device status message
* Added missing system timer to device status message
* Added a nav heading message to easily interpret current filter heading
* Fixed firmware version number reporting in device_report service
* Fixed missing CMakeList services
  
  Updated "Get" services to output data in response (still being tested)
* Changes to CMakeLists committed (changes were made previously, but didn't update for unknown reasons)
  
  Removed unused files
* Launch file didn't commit in previous attempts:
  1) Cleaned-up the file
  2) Renamed the frames for more clear indication of origin
* Code restructured and commented more fully
  
  Quaternions now correct and relative to NED frame
* Changes to cleanup driver:
  1) Services renamed for better interpretation of functionality
  2) Quaternion now output correctly (i.e. wrt NED frame)
  3) Frame definitions changed to represent NED frame
* Update microstrain_3dm.cpp
  Adjusted gyro bias capture to 10 seconds
* Update microstrain_3dm.cpp
* Update microstrain_3dm.cpp
* Merge pull request #15 <https://github.com/clearpathrobotics/ros_mscl/issues/15> from allenh1/get-set-transform-service-improvements
  Get/Set Transform Service Improvements
* Merge pull request #16 <https://github.com/clearpathrobotics/ros_mscl/issues/16> from allenh1/store-mscl-as-unique-ptr
  Store msclInternalNode as a std::unique_ptr<mscl::InertialNode>
* Use the msclInertialNode pointer to check supported commands
* Store the mscl::InertialNode as a std::unique_ptr, and remove unused variable from diagnostic updater
* Add a service call to get the full transform from sensor to vehicle frame
* Replace empty destructor with default keyword
* Rename vehicle translation and rotation offset setting services to better match their function
* Remove unused service
* Fixed sensor to vehicle frame services
* Added ZUPT services
  - cmded_ang_rate_zupt
  - cmded_vel_zupt
  - set_heading_source
  - get_zero_velocity_update_threshold
  - set_zero_velocity_update_threshold
  added optional parameters
  - velocity_zupt_topic
  - angular_zupt_topic
* Added new estfilter channels
* Updated frames
* Added header info to mag msg
* new fields
* Custom message for filter status
* New fields
* New Fields
* Update microstrain_3dm.cpp
* Publishes nav_status
* device_setup parameter for pre-configured nodes
* Change heading_source default value
* Removed structured bindings
  No longer requires support for c++17
* Switched to device and received timestamps
* Updated to include python example information.
* Added python listener example
* Added heading_source parameter
* Added heading_source parameter
* Added /filtered/imu/data
* Added /filtered/imu/data
* Added realpath to Connection
* Update Status Messages
  Updated status reporting to list only supported diagnostic features. This requires mscl version 55.0.1 or later.
* Update README.md - add link to Examples
* Merge branch 'master' of https://github.com/LORD-MicroStrain/microstrain_mips
* 
  
    * move driver package content to ros_mscl folder
    * add name argument to microstrain.launch file to specify the namespace (default: gx5)
    * update README.md
    * add basic subscriber example (C++)
  
* Fix MSCL link
* 1.0.0
  * Added mscl support
  * Removed MIPSDK and utility functions in mip_sdk_user_functions
  * Changed name of node and package to ros_mscl
  * Added device feature detection to improve compatibility with a greater range of devices
  * Added Parker Hannifin Corp to maintainers
* Merge pull request #30 <https://github.com/clearpathrobotics/ros_mscl/issues/30> from ros-drivers/relicense
  Relicense
* package name
* Changing license text
* Changing license text
* Contributors: Bingham, Brian S, Brian Bingham, Chris Iverach-Brereton, Hunter L. Allen, Nathan Miller, mgill, mglord, rdslord
```
