### PR TITLE
ros_mscl: 1.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -646,7 +646,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ros_mscl-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ros_mscl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.1.3-1`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: https://github.com/clearpath-gbp/ros_mscl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.1.2-1`

## ros_mscl

```
* Fix missing dependencies that are breaking the buildfarm
* Contributors: Chris Iverach-Brereton
```
