### PR TITLE
rosserial_leonardo_cmake: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -491,6 +491,21 @@ repositories:
       url: https://github.com/clearpathrobotics/ros_mscl.git
       version: master
     status: maintained
+  rosserial_leonardo_cmake:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/rosserial_leonardo_cmake-release.git
+      version: 0.1.4-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
+      version: hydro-devel
+    status: maintained
   sevcon_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial_leonardo_cmake` to `0.1.4-1`:

- upstream repository: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
- release repository: https://github.com/clearpath-gbp/rosserial_leonardo_cmake-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## rosserial_leonardo_cmake

```
* Updated arduino link from google code
* Contributors: Dave Niewinski
```
