### PR TITLE
rosserial_leonardo_cmake: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -652,6 +652,21 @@ repositories:
       url: https://github.com/clearpathrobotics/ros_mscl.git
       version: master
     status: maintained
+  rosserial_leonardo_cmake:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/rosserial_leonardo_cmake-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
+      version: hydro-devel
+    status: maintained
   sevcon_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial_leonardo_cmake` to `0.1.4-0`:

- upstream repository: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
- release repository: https://github.com/clearpath-gbp/rosserial_leonardo_cmake-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## rosserial_leonardo_cmake

```
* Updated arduino link from google code
* Contributors: Dave Niewinski
```
