### PR TITLE
heron_firmware: 0.3.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -303,6 +303,24 @@ repositories:
       url: https://github.com/heron/heron_desktop.git
       version: kinetic-devel
     status: maintained
+  heron_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/heron_firmware.git
+      version: kinetic-devel
+    release:
+      packages:
+      - heron_avr
+      - heron_firmware
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/heron_firmware-gbp.git
+      version: 0.3.2-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/heron_firmware.git
+      version: kinetic-devel
+    status: maintained
   heron_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_firmware` to `0.3.2-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/heron_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/heron_firmware-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## heron_avr

```
* Put contents back in the upload script, add rosserial_leondardo_cmake to the run_depends
* Merge branch 'power_calc_fix' into 'indigo-devel'
  Fixed calculation from watt-seconds to watt-hours
  See merge request research/heron_firmware!1
* Fixed calculation from watt-seconds to watt-hours
* Added the ability to disable the lights via topic.
* Contributors: Chris Iverach-Brereton, Guy Stoppi, Tony Baltovski
```

## heron_firmware

- No changes
