### PR TITLE
heron_controller: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -193,6 +193,21 @@ repositories:
       url: https://github.com/heron/heron.git
       version: kinetic-devel
     status: maintained
+  heron_controller:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/heron_controller.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/heron_controller-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/heron_controller.git
+      version: indigo-devel
+    status: maintained
   heron_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_controller` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/heron_controller.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/heron_controller-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## heron_controller

```
* Switched from updatePid to computeCommand as it is deprecated control_toolbox.
* Heron rename.
* Contributors: Tony Baltovski
```
