### PR TITLE
heron_robot: 0.1.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -336,6 +336,26 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/heron_firmware.git
       version: kinetic-devel
     status: maintained
+  heron_robot:
+    doc:
+      type: git
+      url: https://github.com/heron/heron_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - heron_base
+      - heron_bringup
+      - heron_nmea
+      - heron_robot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron_robot-release.git
+      version: 0.1.6-1
+    source:
+      type: git
+      url: https://github.com/heron/heron_robot.git
+      version: kinetic-devel
+    status: maintained
   heron_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_robot` to `0.1.6-1`:

- upstream repository: https://github.com/heron/heron_robot.git
- release repository: https://github.com/clearpath-gbp/heron_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## heron_base

```
* Replace now-defunct UM6 as default, use CV5-25 instead, as-per RPSW-661 (#10 <https://github.com/heron/heron_robot/issues/10>)
  * Remove all references to the now-defunct UM6, as-per RPSW-661
  * Add the Microstrain CV5 launch configuration as the new default. We're going to move forward and publish the driver off our own build farm, so depending on it shouldn't cause long-term issues (though it won't work right now)
  * Remove the notes to check topics & devices; they are checked & are correct.
* Merge pull request #9 <https://github.com/heron/heron_robot/issues/9> from heron/mag-arg
  Allow disabling the magnetometer input to the IMU filter
* Add an env var to disable the magnetometer input to the IMU filter, for instances where the IMU does not support that
* Merge pull request #8 <https://github.com/heron/heron_robot/issues/8> from heron/no_imu_compass
  Remove the imu_compass dependency
* Remove the imu_compass dependency, as it does not appear to be used anywhere
* Make the snmp_lights node executable
* Fix a minor formatting typo
* Fix the rosdep for python-pysnmp so it resolves correctly
* Edited heron_robot to work with uuv_simulator (#5 <https://github.com/heron/heron_robot/issues/5>)
  * Removed wireless watcher and mjpeg server
  * Added node to update lights with WiFi status
  * Commented WiFi lights node
  * Removed unnecessary heron_base files and updated other necessary ones
  * Removed install(PROGRAMS scripts/install...)
  * Updated calibration script, currently uses new calibration loading method
  * Added WiFi watcher back in commit
  * Updated calibrate_compass to possibly use a namespace, fixed base.launch to use (mostly) the basic um6 driver, replaced static transforms with robot_description
  * Reverted calibration duration from 10s to 60s
  * Added copyright notice to SNMP lights script, deleted unused calibration write script
  * Replaced kinetic with ROS_DISTRO env var in nmea install script
  * Almost made base.launch work with namespaces (um6, imu_compass can't)
  * Removed enu dependency from heron_nmea package.xml
  * Renamed WiFi topic for Heron's lights to the correct name
  * If not using snmp_lights.py, use old wireless_watcher
  * Updated snmp_lights.py (output topic name and copyright info)
  * Added wireless watcher back as a run dependency for heron_base
  * Added imu_compass.yaml back into PR
  * Moved remap to MCU node
  * Fixed comments in snmp script and removed unnecessary vars in calibrate_compass
  * Removed duplicate dependency
  * Removed imu_compass
  * Added namespace into um6
  * Further adding of namespaces into heron_base
  * Formatting for base.launch
  * Removing extra space
  * Added compute_calibration script in the CMake install() instruciton
* Added script to monitor WiFi and update LEDs accordingly (#4 <https://github.com/heron/heron_robot/issues/4>)
  Added script to monitor WiFi and update LEDs accordingly
* Updated to use heron_control.
* Contributors: Chris I-B, Chris Iverach-Brereton, Guy Stoppi, Tony Baltovski
```

## heron_bringup

```
* Replace now-defunct UM6 as default, use CV5-25 instead, as-per RPSW-661 (#10 <https://github.com/heron/heron_robot/issues/10>)
  * Remove all references to the now-defunct UM6, as-per RPSW-661
  * Add the Microstrain CV5 launch configuration as the new default. We're going to move forward and publish the driver off our own build farm, so depending on it shouldn't cause long-term issues (though it won't work right now)
  * Remove the notes to check topics & devices; they are checked & are correct.
* Edited heron_robot to work with uuv_simulator (#5 <https://github.com/heron/heron_robot/issues/5>)
  * Removed wireless watcher and mjpeg server
  * Added node to update lights with WiFi status
  * Commented WiFi lights node
  * Removed unnecessary heron_base files and updated other necessary ones
  * Removed install(PROGRAMS scripts/install...)
  * Updated calibration script, currently uses new calibration loading method
  * Added WiFi watcher back in commit
  * Updated calibrate_compass to possibly use a namespace, fixed base.launch to use (mostly) the basic um6 driver, replaced static transforms with robot_description
  * Reverted calibration duration from 10s to 60s
  * Added copyright notice to SNMP lights script, deleted unused calibration write script
  * Replaced kinetic with ROS_DISTRO env var in nmea install script
  * Almost made base.launch work with namespaces (um6, imu_compass can't)
  * Removed enu dependency from heron_nmea package.xml
  * Renamed WiFi topic for Heron's lights to the correct name
  * If not using snmp_lights.py, use old wireless_watcher
  * Updated snmp_lights.py (output topic name and copyright info)
  * Added wireless watcher back as a run dependency for heron_base
  * Added imu_compass.yaml back into PR
  * Moved remap to MCU node
  * Fixed comments in snmp script and removed unnecessary vars in calibrate_compass
  * Removed duplicate dependency
  * Removed imu_compass
  * Added namespace into um6
  * Further adding of namespaces into heron_base
  * Formatting for base.launch
  * Removing extra space
  * Added compute_calibration script in the CMake install() instruciton
* Added Ceepulse sonar accessory.
* Updated compass calibration for Heron.
* Contributors: Chris I-B, Guy Stoppi, Tony Baltovski
```

## heron_nmea

```
* [heron_nmea] Switched to std_srvs. (#7 <https://github.com/heron/heron_robot/issues/7>)
* Update to NMEA package to work with the other new packages (#6 <https://github.com/heron/heron_robot/issues/6>)
  * Added possibility of custom namespace into heron_nmea
  * Removed outdated test launch files
  * First step of adding namespaces into heron_nmea
  * Removing unnecessary topic_tools relays
  * Changed NVG position info from EKF algorithm to GPS
  * Had command publisher turn on/off the heron_controller as needed
  * Added nav_msgs as run dependency for nav_publisher
  * Adding namespaces into heron_nmea package
  * Fixed script permissions and service calls
  * Proper parameter loading, permissions
  * Added reference guide for heron_nmea package
  * Further updates to NMEA reference file
  * Updated heron_nmea Reference.MD
  * Changes that were removed for some reason
* Edited heron_robot to work with uuv_simulator (#5 <https://github.com/heron/heron_robot/issues/5>)
  * Removed wireless watcher and mjpeg server
  * Added node to update lights with WiFi status
  * Commented WiFi lights node
  * Removed unnecessary heron_base files and updated other necessary ones
  * Removed install(PROGRAMS scripts/install...)
  * Updated calibration script, currently uses new calibration loading method
  * Added WiFi watcher back in commit
  * Updated calibrate_compass to possibly use a namespace, fixed base.launch to use (mostly) the basic um6 driver, replaced static transforms with robot_description
  * Reverted calibration duration from 10s to 60s
  * Added copyright notice to SNMP lights script, deleted unused calibration write script
  * Replaced kinetic with ROS_DISTRO env var in nmea install script
  * Almost made base.launch work with namespaces (um6, imu_compass can't)
  * Removed enu dependency from heron_nmea package.xml
  * Renamed WiFi topic for Heron's lights to the correct name
  * If not using snmp_lights.py, use old wireless_watcher
  * Updated snmp_lights.py (output topic name and copyright info)
  * Added wireless watcher back as a run dependency for heron_base
  * Added imu_compass.yaml back into PR
  * Moved remap to MCU node
  * Fixed comments in snmp script and removed unnecessary vars in calibrate_compass
  * Removed duplicate dependency
  * Removed imu_compass
  * Added namespace into um6
  * Further adding of namespaces into heron_base
  * Formatting for base.launch
  * Removing extra space
  * Added compute_calibration script in the CMake install() instruciton
* Added script to monitor WiFi and update LEDs accordingly (#4 <https://github.com/heron/heron_robot/issues/4>)
  Added script to monitor WiFi and update LEDs accordingly
* Updated to use heron_control.
* Added vessel light off/on control.
* Added Ceepulse sonar accessory.
* Contributors: Guy Stoppi, Tony Baltovski
```

## heron_robot

```
* Added Ceepulse sonar accessory.
* Contributors: Tony Baltovski
```
