### PR TITLE
dingo_firmware_components: 2.9.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -92,6 +92,12 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_desktop.git
       version: master
     status: maintained
+  dingo_firmware_components:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware_components.git
+      version: 2.9.7-1
   dingo_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_firmware_components` to `2.9.7-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware_components.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## dingo_firmware_components

```
* Change python-tftpy dep.
* Contributors: Tony Baltovski
```
