### PR TITLE
dingo_firmware: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -92,6 +92,21 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_desktop.git
       version: master
     status: maintained
+  dingo_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git
+      version: melodic-devel
+    status: maintained
   dingo_firmware_components:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_firmware` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## dingo_firmware

```
* Made roslint a test dep.
* Reset package version.
* Switched to dingo_firmware_components.
* Added user input & outputs and respective publisher & subscriber.  Switched from dingo_msg/Power to std_msgs/Bool.  Added some more consts.
* Averaging system battery level over 30 seconds
* Updated README.md
* Cleanup.
* Synched up all batteries for publishing the battery status message
  Batteries can now be hot swapped without blocking the SMBus
* Changed lwip to use RAM rather than static memory pools
  Burst UDP packets will not be dropped now
* WIP: Lithium batteries
  - Mostly working mux and battery drivers
  Bugs:
  - Disconnecting a battery causes bus to die
  - Connecting an additional battery creates a separate message for that battery
* Memset slcan buffer to clear the unused buffer
* Changed motor button interrupt trigger to rising edge
* Added SMBUS initialization
* 
  
    * Added AUX input and output pin definitions
    * CAN read/write is indicated on debug led 3 and 4
  
* Network logger is connected when node handle connects
* Updated ADC current scaling
* Updated IMU orientation
* Using SLCAN from firmware components
  Updated how SLCAN from network is received
* 
  
    * Removed stop.status pin
    * Removed CAN logs
  
* Increased max ping fail to 25
  Status publishes at 10hz
* Cleanup.
* Added CAN1.
* Removed led state from lighting.cpp
* change
* SLCAN changes
* Updated battery level logic
* Removed linker line in CMakeList
* 
  
    * stop_engaged status is now based on motor_stop pin
  
* linker name change
* Updated lighting
* Corrected logic for valid_shore and valid_battery
* Melodic changes
* Updated HMI Battery LED states:
  - Shore power -> Green blinking
  - Battery good -> Green solid
  - Battery warning -> Amber solid
  - Battery low -> Red solid
* Updated ADC voltage scaling values
* Network logger queue changes
* Corrected IMU interrupt pin
* Added launch file for testing
* 
  
    * ROS Subscribers are now pointers, fixes segfault issue
    * Reduced task interface queue sizes to 1
  
* Polling AUX button because EXTI12 is already in use
  AUX button will enable/disable 12v
* 
  
    * Set pin G7 to input as it is power button feedback
    * Added I2C2 initialization
  
* 
  
    * Added initialization for CAN1 circular buffer
  
* Added CAN1
  Added firmware_version to /mcu/status message
* Resolve RPMIR-76
* 
  
    * Fixed issue with dingo_msgs/*.h not being included
    * Added Mock HMI and Stop
    * Updated all tests to use new Mock files
  
* Initial main task test
* Added Mock Cooling, Hardware, Lighting, Power
* initial- not working
* Minor fix
* Check that imu_hardware object is not null
* Replaced ICM20948 driver with ImuHardware which automatically detects the IMU
* 
  
    * Added bootloader keepalive configuration
    * Minor cleanup
  
* Bootloader keepalive
* Icm20948 interrupt fix and minor cleanup
* Freertos, lwIP, bootloader
* Removed system/i2c_hack since it isn't being used
* Fix comment regarding asserting a stop at startup
* Updates to match name of power_12v_user_nominal field in Status.msg
* Changed fans from being an array of one to a non-array item. This is aligned with the corresponding change to Fans.msg
* Initial Dingo firmware implementation; not yet tested on real board
* Adding initial README file
* Contributors: Jason Higgins, Roni Kreinin, Tony Baltovski
```
