### PR TITLE
teleop_twist_joy: 2.4.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5,6 +5,21 @@
 release_platforms:
   ubuntu:
   - focal
-repositories: []
+repositories:
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
+      version: 2.4.1-1
+    source:
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: foxy
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.4.1-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## teleop_twist_joy

```
* Add parameter to enable/disable requiring the enable button to be held for motion (#21 <https://github.com/ros2/teleop_twist_joy/issues/21>)
* Contributors: Chris Lalancette, kgibsonjca
```
