### PR TITLE
cpr_common_msgs: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -21,6 +21,26 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
       version: devel
     status: maintained
+  cpr_common_msgs:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/cpr_common_msgs.git
+      version: master
+    release:
+      packages:
+      - cpr_common_msgs
+      - cpr_common_srvs
+      - gpio_msgs
+      - led_array_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/boxer_gbp/cpr_common_msgs.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/Boxer/cpr_common_msgs.git
+      version: master
+    status: maintained
   cpr_gps_common:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_common_msgs` to `0.0.1-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:Boxer/cpr_common_msgs.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/cpr_common_msgs.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## cpr_common_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## cpr_common_srvs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## gpio_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## led_array_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```
