### PR TITLE
microhard_snmp: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -430,6 +430,21 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/launch_delay.git
       version: main
     status: maintained
+  microhard_snmp:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/microhard_snmp.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/microhard_snmp.git
+      version: kinetic-devel
+    status: maintained
   moose:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microhard_snmp` to `0.0.1-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/microhard_snmp.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## microhard_snmp

```
* Initial Release
* Contributors: Michael Hosmar, Shrey Kavi
```
