### PR TITLE
dingo_firmware_components: 2.9.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -130,7 +130,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware_components.git
-      version: 2.9.10-1
+      version: 2.9.11-1
   dingo_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_firmware_components` to `2.9.11-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware_components.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.9.10-1`

## dingo_firmware_components

```
* Renamed folder.
* Contributors: Tony Baltovski
```
