### PR TITLE
heron_desktop: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -247,6 +247,24 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/heron_controller.git
       version: indigo-devel
     status: maintained
+  heron_desktop:
+    doc:
+      type: git
+      url: https://github.com/heron/heron_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - heron_desktop
+      - heron_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron_desktop-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/heron/heron_desktop.git
+      version: kinetic-devel
+    status: maintained
   heron_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_desktop` to `0.0.3-1`:

- upstream repository: https://github.com/heron/heron_desktop.git
- release repository: https://github.com/clearpath-gbp/heron_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## heron_desktop

- No changes

## heron_viz

```
* Merge pull request #1 <https://github.com/heron/heron_desktop/issues/1> from ssubramaniam-cpr/kinetic-devel
  Changed interactive marker topic update
* Changed interative marker topic update
* Contributors: Shreya Subramaniam, Tony Baltovski
```
