### PR TITLE
dingo: 0.1.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -86,7 +86,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.6-2
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.7-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.6-2`

## dingo_control

- No changes

## dingo_description

```
* Add env var support for VLP-16 (#10 <https://github.com/dingo-cpr/dingo/issues/10>)
  * Add support for the VLP16 as a standard laser sensor on this platform
  * Add vlp16 to the comment block explaining supported laser scanners
  * Add the 3D and secondary 2D lidars
* Contributors: Chris I-B
```

## dingo_msgs

- No changes

## dingo_navigation

- No changes
