### PR TITLE
dingo_robot: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -144,7 +144,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.1.3-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.2-1`

## dingo_base

- No changes

## dingo_bringup

```
* Move the VLP16 to a new DINGO_LASER_3D family of vars, add DINGO_LASER_SECONDARY
* Add vlp16 to the commend block explaining allowed values
* Add support for the VLP16 as a standard laser sensor for Dingo
* Contributors: Chris Iverach-Brereton
```

## dingo_robot

- No changes
