### PR TITLE
jackal_robot: 0.6.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -427,7 +427,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.6.1-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.6.0-1`

## jackal_base

```
* Use eval to find the mag config. This should fix a bug when jackal is installed to ros.d
* Set default for optenv JACKAL_MAG_CONFIG
* Removed env-hooks
* Contributors: Chris Iverach-Brereton, Dave Niewinski
```

## jackal_bringup

```
* Add VLP16 support, refactor main/secondary laser envar support (#27 <https://github.com/jackal/jackal_robot/issues/27>)
  * Add groups for the front/rear fender lasers' nodes
  * Revert the front/rear laser frames to "front_laser" and "rear_laser" respectively, to match with the frames in jackal_description (proposed PR to rename them was rejected)
  * Enable launching the secondary 2D laser, and the primary 3D laser
  * Rename LASER2 to LASER_SECONDARY
  * Change the default mount for the 3d laser to the middle
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Remove the PS4 symlink; we've consolidated the udev rules and are relying on ds4drv to provide that rule now
* Contributors: Chris I-B, Chris Iverach-Brereton
```

## jackal_robot

- No changes
