### PR TITLE
warthog: 0.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -780,7 +780,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.3-1`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.2-1`

## warthog_control

```
* Bumped CMake version to avoid author warning.
* Change the enable & enable-turbo buttons to 4 and 5 to match with all the other platforms
* Add another optenv to allow setting the Warthog's joy device
* Config extras (#12 <https://github.com/warthog-cpr/warthog/issues/12>)
  * Add a WARTHOG_CONFIG_EXTRAS environment variable for the same purpose as the equivalent in Husky.
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## warthog_description

```
* Bumped CMake version to avoid author warning.
* Contributors: Tony Baltovski
```

## warthog_msgs

```
* Bumped CMake version to avoid author warning.
* Contributors: Tony Baltovski
```
