### PR TITLE
heron_simulator: 0.3.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -368,7 +368,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_simulator-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/heron/heron_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_simulator` to `0.3.3-1`:

- upstream repository: https://github.com/heron/heron_simulator.git
- release repository: https://github.com/clearpath-gbp/heron_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.2-1`

## heron_gazebo

```
* Pass the config arg to the heron_description package correctly
* Contributors: Chris Iverach-Brereton
```

## heron_simulator

- No changes
