### PR TITLE
cpr_gps_navigation: 0.1.19-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -155,17 +155,17 @@ repositories:
   cpr_gps_navigation:
     release:
       packages:
+      - cpr_gps_costmap_layers
       - cpr_gps_localization
       - cpr_gps_navigation
       - cpr_gps_navigation_client
       - cpr_gps_navigation_server
       - cpr_gps_path_smoothing
       - cpr_gps_safety
-      - cpr_gps_tasks
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.17-1
+      version: 0.1.19-2
     status: maintained
   firmware_components:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.19-2`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.17-1`

## cpr_gps_costmap_layers

- No changes

## cpr_gps_localization

- No changes

## cpr_gps_navigation

```
* fix package name
* Contributors: Ebrahim
```

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

- No changes

## cpr_gps_path_smoothing

- No changes

## cpr_gps_safety

- No changes
