### PR TITLE
jackal: 0.7.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -378,7 +378,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.7.4-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.7.3-1`

## jackal_control

```
* Bumped CMake version to avoid author warning.
* Add the JACKAL_JOY_DEVICE envar to optionally override the joy device more easily.
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## jackal_description

```
* Bumped CMake version to avoid author warning.
* Contributors: Tony Baltovski
```

## jackal_msgs

```
* Bumped CMake version to avoid author warning.
* Contributors: Tony Baltovski
```

## jackal_navigation

```
* Bumped CMake version to avoid author warning.
* Contributors: Tony Baltovski
```
