### PR TITLE
occupancy_grid_utils: 0.0.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -534,6 +534,17 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/moose_robot.git
       version: master
     status: maintained
+  occupancy_grid_utils:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/occupancy_grid_utils-release.git
+      version: 0.0.11-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/occupancy_grid_utils.git
+      version: indigo-devel
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `occupancy_grid_utils` to `0.0.11-1`:

- upstream repository: https://github.com/clearpathrobotics/occupancy_grid_utils
- release repository: https://github.com/clearpath-gbp/occupancy_grid_utils-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## occupancy_grid_utils

```
* Drop signals boost component.
* Contributors: Mike Purvis
```
