### PR TITLE
image_undistort: 0.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -363,6 +363,17 @@ repositories:
       url: https://github.com/husky/husky_cartographer_navigation.git
       version: melodic-devel
     status: developed
+  image_undistort:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/image_undistort-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/image_undistort.git
+      version: master
+    status: maintained
   jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_undistort` to `0.0.1-2`:

- upstream repository: https://github.com/clearpathrobotics/image_undistort.git
- release repository: https://github.com/clearpath-gbp/image_undistort-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## image_undistort

```
* Initial tagged release.
* Contributors: Dominik Schindler, Helen Oleynikova, Raghav Khanna, Tracey Spicer, Vaibhav Kumar Mehta, Zachary Taylor
```
