### PR TITLE
cpr_docking: 0.0.4-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -61,7 +61,7 @@ repositories:
       - target_tracker_client
       tags:
         release: release/melodic/{package}/{version}
-      url: git@gitlab.clearpathrobotics.com:gbp/cpr_docking-gbp.git
+      url: http://gitlab.clearpathrobotics.com/gbp/cpr_docking-gbp.git
       version: 0.0.4-4
     status: maintained
   cpr_gps_common:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -62,7 +62,8 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: git@gitlab.clearpathrobotics.com:gbp/cpr_docking-gbp.git
-      version: 0.0.4-1
+      version: 0.0.4-4
+    status: maintained
   cpr_gps_common:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_docking` to `0.0.4-4`:

- upstream repository: http://gitlab.clearpathrobotics.com/gps-navigation/cpr_docking.git
- release repository: git@gitlab.clearpathrobotics.com:gbp/cpr_docking-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.0.4-1`

## apriltag_msgs

- No changes

## bfc_scan_matcher

- No changes

## cpr_autonomy_geometry

- No changes

## cpr_autonomy_utils

- No changes

## cpr_docking

- No changes

## cpr_filters

- No changes

## cpr_gps_docking_server

- No changes

## cpr_slam_msgs

- No changes

## cpr_slam_utils

```
* Contributors: Ebrahim Shahrivar
```

## laser_target_tracker

- No changes

## lttng_trace_ros

- No changes

## lttng_trace_system

- No changes

## odom_covariance_filter

- No changes

## shared_message_storage

- No changes

## target_tracker_client

- No changes
