### PR TITLE
cpr_docking: 0.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -62,7 +62,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_docking-gbp.git
-      version: 0.0.4-4
+      version: 0.0.5-1
     status: maintained
   cpr_gps_common:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_docking` to `0.0.5-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/gps-navigation/cpr_docking.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_docking-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.0.4-4`

## apriltag_msgs

- No changes

## bfc_scan_matcher

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## cpr_autonomy_geometry

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## cpr_autonomy_utils

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## cpr_docking

- No changes

## cpr_filters

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## cpr_gps_docking_server

- No changes

## cpr_slam_msgs

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## cpr_slam_utils

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## laser_target_tracker

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## lttng_trace_ros

- No changes

## lttng_trace_system

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## odom_covariance_filter

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## shared_message_storage

```
* roslint fix
* Contributors: Ebrahim Shahrivar
```

## target_tracker_client

- No changes
