### PR TITLE
gps_mpc_navigation: 0.1.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -192,7 +192,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
-      version: 0.1.7-1
+      version: 0.1.8-1
     status: maintained
   grizzly:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.1.8-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/gps_mpc_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.7-1`

## cpr_local_planner

- No changes

## cpr_pathtracker

```
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## gps_mpc_navigation

- No changes

## grid_library

- No changes
