### PR TITLE
cpr_common_core: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -21,6 +21,23 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/software/canfestival_ros.git
       version: devel
     status: maintained
+  cpr_common_core:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_common_core.git
+      version: master
+    release:
+      packages:
+      - cpr_common_core_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_common_core-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_common_core.git
+      version: master
+    status: maintained
   cpr_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_common_core` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_common_core.git
- release repository: https://github.com/clearpath-gbp/cpr_common_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `null`

## cpr_common_core_msgs

```
* [cpr_common_core_msgs] Added messages.
* Contributors: Tony Baltovski
```
