### PR TITLE
ros_mscl: 1.2.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -718,10 +718,13 @@ repositories:
       url: https://github.com/clearpathrobotics/ros_mscl.git
       version: master
     release:
+      packages:
+      - mscl_msgs
+      - ros_mscl
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ros_mscl-release.git
-      version: 1.1.4-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ros_mscl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.2.3-1`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: https://github.com/clearpath-gbp/ros_mscl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.1.4-1`

## mscl_msgs

```
* Merge the recent upstream changes so we're compatible with MSCL 61.1.6.
* Keep the old version numbers, re-add our postinst and postrm scripts, but otherwise keep the structure of the repo the same as upstream; this should make it easier to update our repo down the road.
* Driver modified to support MSCL version 61.1.6
* Fixed missing boolean set for RTK status message publishing
* Merge pull request #34 <https://github.com/clearpathrobotics/ros_mscl/issues/34> from CaptKrasno/msg
* Separated Messages into a second package and changed naming to match ros convention
* Contributors: Chris Iverach-Brereton, Kristopher Krasnosky, Nathan Miller, nathanmillerparker
```

## ros_mscl

```
* Merge the recent upstream changes so we're compatible with MSCL 61.1.6.
* Keep the old version numbers, re-add our postinst and postrm scripts, but otherwise keep the structure of the repo the same as upstream; this should make it easier to update our repo down the road.
* Added frame ids back in to not break existing configurations
* Added a flag to set ENU as the local reference frame
  Moved sensor2vehicle frame transformation setting code to occur if filter data is not enabled
  See changelog for more info
* Added user notifications in the case a command isn't supported by a device.
  Added support for the speedometer lever arm offset command
* Corrected description in launch file to point out the quaternion version of the sensor2vehicle frame transformation is not currently supported on the GQ7
* Added ROS_INFO/ROS_ERROR reporting for setting sensor2vehicle frame transformation... had a silent error for the quaternion version on the GQ7.
* Added the filter GPS timestamp packet to the configured messages.
* 
  
    * Driver modified to support MSCL version 61.1.6
    * Fixed missing boolean set for RTK status message publishing
  
* Timestamp change:
  1. Launch file setting "use_device_timestamp" (bool) created to allow user to select between device generated timestamp and packet received time (generated using PC time upon packet reception.)
  - Some applications require the PC received time to sync with other packages
  - Some applications require the device generated timestamp for accurate time of when the data was generated
  Hopefully, this satisfies both needs.
* Merge pull request #36 <https://github.com/clearpathrobotics/ros_mscl/issues/36> from arpg/master
  Fixed issue including mscl_msgs
* Fixed issue including mscl_msgs
* Merge pull request #34 <https://github.com/clearpathrobotics/ros_mscl/issues/34> from CaptKrasno/msg
  Moved Messages to Separate Package and renamed them to match ros convention
* Merge branch 'master' into msg
* Warning: Contains breaking change to /nav/odom message!
  Code cleanup, new features, bug fixes
  See changelog for complete list of changes
* Separated Messages into a second package and changed naming to match ros convention
* Merge remote-tracking branch 'upstream/master'
* Merge pull request #30 <https://github.com/clearpathrobotics/ros_mscl/issues/30> from CaptKrasno/gps_corr
  Added support for gps_correlation_timestamp packet
* changed default value for  m_publish_gps_corr to false
* Merge branch 'master' into gps_corr
* Merge pull request #31 <https://github.com/clearpathrobotics/ros_mscl/issues/31> from CaptKrasno/gravity
  redefined g according to the spec
* redefined g according to the spec
* Added support for gps_correlation_timestamp packet
* Modified filter, GNSS, and RTK timestamp handling to disregard valid flags (to match IMU handling)
* Added IMU GPS timestamp as a default data setup quantity.
  Removed IMU timestamp validity check so time still streams prior to GPS lock.
* Fixed bug preventing device report service from working on a GQ7.
* Added support for raw binary file output and RTK status message (see changelog for details)
* Added PPS Source, GPIO Config, and external GPS time updating
* Added feature checking for filter reset and imu category
* Fixed driver error that tried to publish magnetometer data when it is not present
* Added device Idle prior to shutdown to play nice across host power cycles
  
  Fixed flags used to determine valid time for GNSS time message
* Fixed time reference output to use ROS time for header timestamp
* sensor_msgs::TimeReference added per user request
* Added a resume command at the end of device setup as the GQ7 needs it.
* Changed GQ7 filter init alignment selector to a bitfield in the example launch file
  
  Fixed quaternion sensor2vehicle frame rotation (negated the indices instead of the values by accident)
* See changelog for full details.
  Added support for GQ7
  Changed "GPS" topic to "GNSS1" and added "GNSS2"
  Refactored code
* Added Device Settings service:  Supports function selectors: 3 (Save), 4 (Load Saved), 5 (Load Defaults)
* Added nav filter heading state feedback
* Only doing device_status_callback() at 1 Hz now
* Fully filled-out device status message
* Added missing system timer to device status message
* Added a nav heading message to easily interpret current filter heading
* Fixed firmware version number reporting in device_report service
* Fixed missing CMakeList services
  
  Updated "Get" services to output data in response (still being tested)
* Changes to CMakeLists committed (changes were made previously, but didn't update for unknown reasons)
  
  Removed unused files
* Launch file didn't commit in previous attempts:
  1) Cleaned-up the file
  2) Renamed the frames for more clear indication of origin
* Code restructured and commented more fully
  
  Quaternions now correct and relative to NED frame
* Changes to cleanup driver:
  1) Services renamed for better interpretation of functionality
  2) Quaternion now output correctly (i.e. wrt NED frame)
  3) Frame definitions changed to represent NED frame
* Update microstrain_3dm.cpp
  Adjusted gyro bias capture to 10 seconds
* Update microstrain_3dm.cpp
* Update microstrain_3dm.cpp
* Merge pull request #15 <https://github.com/clearpathrobotics/ros_mscl/issues/15> from allenh1/get-set-transform-service-improvements
  Get/Set Transform Service Improvements
* Merge pull request #16 <https://github.com/clearpathrobotics/ros_mscl/issues/16> from allenh1/store-mscl-as-unique-ptr
  Store msclInternalNode as a std::unique_ptr<mscl::InertialNode>
* Use the msclInertialNode pointer to check supported commands
* Store the mscl::InertialNode as a std::unique_ptr, and remove unused variable from diagnostic updater
* Add a service call to get the full transform from sensor to vehicle frame
* Replace empty destructor with default keyword
* Rename vehicle translation and rotation offset setting services to better match their function
* Remove unused service
* Fixed sensor to vehicle frame services
* Added ZUPT services
  - cmded_ang_rate_zupt
  - cmded_vel_zupt
  - set_heading_source
  - get_zero_velocity_update_threshold
  - set_zero_velocity_update_threshold
  added optional parameters
  - velocity_zupt_topic
  - angular_zupt_topic
* Added new estfilter channels
* Updated frames
* Added header info to mag msg
* new fields
* Custom message for filter status
* New fields
* New Fields
* Update microstrain_3dm.cpp
* Publishes nav_status
* device_setup parameter for pre-configured nodes
* Change heading_source default value
* Removed structured bindings
  No longer requires support for c++17
* Switched to device and received timestamps
* Added heading_source parameter
* Added heading_source parameter
* Added /filtered/imu/data
* Added /filtered/imu/data
* Added realpath to Connection
* Update Status Messages
  Updated status reporting to list only supported diagnostic features. This requires mscl version 55.0.1 or later.
* 
  
    * move driver package content to ros_mscl folder
    * add name argument to microstrain.launch file to specify the namespace (default: gx5)
    * update README.md
    * add basic subscriber example (C++)
  
* Contributors: Chris Iverach-Brereton, Hunter L. Allen, Kristopher Krasnosky, Nathan Miller, harelb, mgill, nathanmillerparker, rdslord
```
