### PR TITLE
ros_mscl: 1.2.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -696,7 +696,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ros_mscl-release.git
-      version: 1.2.3-1
+      version: 1.2.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ros_mscl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.2.4-1`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: https://github.com/clearpath-gbp/ros_mscl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.2.3-1`

## mscl_msgs

- No changes

## ros_mscl

```
* Add an argument to specify the frame_id, instead of always using "sensor"
* Contributors: Chris Iverach-Brereton
```
