### PR TITLE
lockmount_description: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -59,21 +59,6 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
       version: melodic-devel
     status: developed
-  lockmount_description:
-    doc:
-      type: git
-      url: https://github.com/clearpathrobotics/lockmount_description.git
-      version: main
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/clearpath-gbp/lockmount_description-release.git
-      version: 0.0.1-1
-    source:
-      type: git
-      url: https://github.com/clearpathrobotics/lockmount_description.git
-      version: main
-    status: maintained
   jackal_robot:
     doc:
       type: git
@@ -110,6 +95,21 @@ repositories:
       url: https://github.com/jackal/jackal_simulator.git
       version: melodic-devel
     status: developed
+  lockmount_description:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/lockmount_description.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/lockmount_description-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/lockmount_description.git
+      version: main
+    status: maintained
   ros_mscl:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  lockmount_description:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/lockmount_description.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/lockmount_description-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/lockmount_description.git
+      version: main
+    status: maintained
   ros_mscl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lockmount_description` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/lockmount_description.git
- release repository: https://github.com/clearpath-gbp/lockmount_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## lockmount_description

```
* Initial release
* Contributors: Chris Iverach-Brereton
```
