### PR TITLE
lockmount_description: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -500,6 +500,21 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/launch_delay.git
       version: main
     status: maintained
+  lockmount_description:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/lockmount_description.git
+      version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/lockmount_description-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/lockmount_description.git
+      version: main
+    status: maintained
   microhard_snmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lockmount_description` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/lockmount_description.git
- release repository: https://github.com/clearpath-gbp/lockmount_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## lockmount_description

```
* Initial release
* Contributors: Chris Iverach-Brereton
```
