### PR TITLE
dingo_firmware: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -159,7 +159,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware-gbp.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_firmware` to `0.1.4-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.1.3-1`

## dingo_firmware

```
* Installed missing script.
* Contributors: Tony Baltovski
```
