### PR TITLE
ros_mscl: 1.2.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -696,7 +696,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ros_mscl-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ros_mscl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.2.5-1`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: https://github.com/clearpath-gbp/ros_mscl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.4-1`

## mscl_msgs

- No changes

## ros_mscl

```
* Merge branch 'master' of github.com:LORD-MicroStrain/ROS-MSCL into upstream-sync
* Merge pull request #49 <https://github.com/clearpathrobotics/ros_mscl/issues/49> from civerachb-cpr/rosdep-fix
  Add tf2_geometry_msgs as a dependency
* Add tf2_geometry_msgs as a dependency
* Merge pull request #48 <https://github.com/clearpathrobotics/ros_mscl/issues/48> from civerachb-cpr/master
  Make frame IDs configurable
* Contributors: Chris Iverach-Brereton, nathanmillerparker
```
