### PR TITLE
ros_mscl: 1.2.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -18,7 +18,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ros_mscl-release.git
-      version: 1.2.5-1
+      version: 1.2.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ros_mscl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.2.6-1`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: https://github.com/clearpath-gbp/ros_mscl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.5-1`

## mscl_msgs

- No changes

## ros_mscl

```
* Expose the use_enu_frame parameter as an arg
* Contributors: Chris Iverach-Brereton
```
