### PR TITLE
jackal_firmware: 0.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  jackal_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
+      version: 0.4.3-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
+      version: melodic-devel
+    status: developed
   ros_mscl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.4.3-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/jackal_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## jackal_firmware

```
* Used integer for time rather then float.
* Contributors: Tony Baltovski
```
