### PR TITLE
jackal: 0.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,6 +6,27 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  jackal:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: noetic-devel
+    release:
+      packages:
+      - jackal_control
+      - jackal_description
+      - jackal_msgs
+      - jackal_navigation
+      - jackal_tutorials
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal-release.git
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: noetic-devel
+    status: developed
   jackal_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.0-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## jackal_control

```
* Merge branch 'noetic-devel-bkup' into noetic-devel
* Fix the link_name parameter for the interactive marker server; the default for the package includes a leading '/', which prevents the markers from working on Noetic.  We can revert this if/when the default for interactive_marker_twist_server is modified.
* Contributors: Chris Iverach-Brereton
```

## jackal_description

- No changes

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
