### PR TITLE
jackal_robot: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -21,6 +21,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
       version: melodic-devel
     status: developed
+  jackal_robot:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: noetic-devel
+    release:
+      packages:
+      - jackal_base
+      - jackal_bringup
+      - jackal_robot
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_robot-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: noetic-devel
+    status: developed
   ros_mscl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.7.0-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## jackal_base

```
* Merge development changes from live hardware test into noetic-devel
* Sort the jackal_base changelog version tags
* Fix the scipy dependency so it resolves properly. Minor code cleanup
* Contributors: Chris I-B, Chris Iverach-Brereton
```

## jackal_bringup

```
* Merge development changes from live hardware test into noetic-devel
* Fix the name of the VLP16 launch file that gets included in accessories
* Fix a c&p error where and arg was referenced before it was actually assigned
* Merge pull request #24 <https://github.com/jackal/jackal_robot/issues/24> from ScottMcCormack/noetic-devel
  Fixed typo with OSError exception handling
* Apply python 3 fixes.  Note: the lambda function in network.py is auto-generated, and the original is in a comment in case there are problems down the road.
* Contributors: Chris I-B, Chris Iverach-Brereton, Scott McCormack
```

## jackal_robot

```
* Merge development changes from live hardware test into noetic-devel
* Contributors: Chris I-B, Chris Iverach-Brereton
```
