### PR TITLE
lockmount_description: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -509,7 +509,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/lockmount_description-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/lockmount_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lockmount_description` to `0.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/lockmount_description.git
- release repository: https://github.com/clearpath-gbp/lockmount_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`

## lockmount_description

```
* Remove a copy & paste error in the cmake file that's breaking the install
* Contributors: Chris Iverach-Brereton
```
