### PR TITLE
ros_mscl: 1.2.7-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -122,7 +122,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: git@github.com:clearpath-gbp/ros_mscl-release.git
-      version: 1.2.7-2
+      version: 1.2.7-3
     source:
       type: git
       url: https://github.com/clearpathrobotics/ros_mscl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.2.7-3`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: git@github.com:clearpath-gbp/ros_mscl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.7-2`

## mscl_msgs

```
* Explicitly name the mscl_msgs package
* Contributors: Chris Iverach-Brereton
```

## ros_mscl

- No changes
