### PR TITLE
jackal_simulator: 0.4.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -89,7 +89,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_simulator-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/jackal/jackal_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_simulator` to `0.4.0-2`:

- upstream repository: https://github.com/jackal/jackal_simulator
- release repository: https://github.com/clearpath-gbp/jackal_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## jackal_gazebo

```
* Enable the joystick by default. Add yaw to the spawn_jackal launch file
* Add an additional parameter to enable teleop in the simulations
* Fix an accidental deletion of a closing tag
* Move the jackal-spawning into a separate launch file for compatibility with the new sim environments.  Add additional sim worlds: completely empty (useful for replaying bag files w/o risk of obstacle collisions!) and HRTAC since the world was in the repo, but not actually used
* Contributors: Chris I-B, Chris Iverach-Brereton, Dave Niewinski, Tony Baltovski
```

## jackal_simulator

- No changes
