### PR TITLE
firmware_components: 2.9.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,6 +6,12 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  firmware_components:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: git@gitlab.clearpathrobotics.com:gbp/firmware_components-gbp.git
+      version: 2.9.5-1
   jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `firmware_components` to `2.9.5-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/firmware_components.git
- release repository: git@gitlab.clearpathrobotics.com:gbp/firmware_components-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## firmware_components

- No changes
