### PR TITLE
ros_mscl: 1.2.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -711,7 +711,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ros_mscl-release.git
-      version: 1.2.7-1
+      version: 1.2.8-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ros_mscl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.2.8-1`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: https://github.com/clearpath-gbp/ros_mscl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.7-1`

## mscl_msgs

- No changes

## ros_mscl

```
* Make the libmscl a normal depend, not just a build_depend.
* Use [ ... ] instead of [[ ... ]] in the postinst and postrm scripts
* Contributors: Chris Iverach-Brereton
```
