### PR TITLE
jackal_firmware: 0.4.3-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -59,7 +59,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
-      version: 0.4.3-2
+      version: 0.4.3-3
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.4.3-3`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/jackal_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.3-2`

## jackal_firmware

```
* Used integer for time rather then float.
* Contributors: Tony Baltovski
```
