### PR TITLE
cpr_gps_tasks: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -112,6 +112,17 @@ repositories:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
       version: 0.1.19-6
+  cpr_gps_tasks:
+    release:
+      packages:
+      - cpr_gps_camera_tasks
+      - cpr_gps_generic_tasks
+      - cpr_gps_tasks
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
+      version: 0.0.2-1
+    status: maintained
   dingo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_tasks` to `0.0.2-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/gps-navigation/cpr_gps_tasks.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## cpr_gps_camera_tasks

- No changes

## cpr_gps_generic_tasks

- No changes

## cpr_gps_tasks

- No changes
