### PR TITLE
cpr_gps_common: 0.1.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -86,6 +86,7 @@ repositories:
       packages:
       - autonomy_msgs
       - autonomy_msgs_utils
+      - cpr_autonomy_metrics
       - cpr_diagnostics
       - cpr_estop_monitor
       - cpr_gps_common
@@ -97,7 +98,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
-      version: 0.1.7-1
+      version: 0.1.8-1
   cpr_gps_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.8-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.7-1`

## autonomy_msgs

```
* Contributors: Jose Mastrangelo
```

## autonomy_msgs_utils

- No changes

## cpr_autonomy_metrics

```
* Merge branch 'fix/autonomy_metrics' into 'master'
* Contributors: José Mastrangelo
```

## cpr_diagnostics

- No changes

## cpr_estop_monitor

- No changes

## cpr_gps_common

- No changes

## cpr_gps_navigation_msgs

```
* Merge branch 'autonomy_task' into 'master'
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_pointcloud_filter

- No changes

## cpr_std_srvs

- No changes

## nav_core_cpr

- No changes

## nav_utils

- No changes
