### PR TITLE
cpr_gps_navigation: 0.1.20-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -111,7 +111,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.19-6
+      version: 0.1.20-1
   cpr_gps_tasks:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.20-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.19-6`

## cpr_gps_costmap_layers

```
* merge path planning constraints
* Contributors: Ebrahim Shahrivar
```

## cpr_gps_localization

```
* Merge branch 'feature/lidar_odometry' into 'master'
* Contributors: Ebrahim Shahrivar
```

## cpr_gps_navigation

```
* merge path planning constraints
* Contributors: Ebrahim Shahrivar
```

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

```
* Contributors: Ebrahim Shahrivar, José Mastrangelo, Mike Hosmar
```

## cpr_gps_path_smoothing

- No changes

## cpr_gps_safety

- No changes
