### PR TITLE
cpr_gps_tasks: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -122,7 +122,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     status: maintained
   dingo:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_tasks` to `0.0.3-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/gps-navigation/cpr_gps_tasks.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.0.2-1`

## cpr_gps_camera_tasks

```
* release changes
* Contributors: Ebrahim Shahrivar
```

## cpr_gps_generic_tasks

```
* release changes
* Contributors: Ebrahim Shahrivar
```

## cpr_gps_tasks

```
* release changes
* Contributors: Ebrahim Shahrivar
```
