### PR TITLE
cpr_gps_common: 0.1.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -89,6 +89,7 @@ repositories:
       - cpr_autonomy_metrics
       - cpr_diagnostics
       - cpr_estop_monitor
+      - cpr_geodetic_survey
       - cpr_gps_common
       - cpr_gps_navigation_msgs
       - cpr_pointcloud_filter
@@ -98,7 +99,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
-      version: 0.1.8-1
+      version: 0.1.9-1
   cpr_gps_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.9-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.8-1`

## autonomy_msgs

- No changes

## autonomy_msgs_utils

- No changes

## cpr_autonomy_metrics

- No changes

## cpr_diagnostics

- No changes

## cpr_estop_monitor

- No changes

## cpr_geodetic_survey

```
* Contributors: José Mastrangelo
```

## cpr_gps_common

- No changes

## cpr_gps_navigation_msgs

- No changes

## cpr_pointcloud_filter

- No changes

## cpr_std_srvs

- No changes

## nav_core_cpr

- No changes

## nav_utils

- No changes
