### PR TITLE
cpr_docking: 0.0.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -79,7 +79,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_docking-gbp.git
-      version: 0.0.8-1
+      version: 0.0.9-1
     status: maintained
   cpr_gps_common:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_docking` to `0.0.9-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/gps-navigation/cpr_docking.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_docking-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.0.8-1`

## apriltag_msgs

- No changes

## bfc_scan_matcher

- No changes

## cpr_autonomy_geometry

- No changes

## cpr_autonomy_utils

- No changes

## cpr_docking

- No changes

## cpr_filters

- No changes

## cpr_gps_docking

- No changes

## cpr_slam_msgs

- No changes

## cpr_slam_utils

- No changes

## laser_target_tracker

- No changes

## lttng_trace_ros

- No changes

## lttng_trace_system

- No changes

## odom_covariance_filter

- No changes

## shared_message_storage

- No changes

## target_tracker_client

```
* yaml-cpp dependency
* Contributors: Ebrahim Shahrivar
```
