### PR TITLE
heron_robot: 0.1.7-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -351,7 +351,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_robot-release.git
-      version: 0.1.7-1
+      version: 0.1.7-2
     source:
       type: git
       url: https://github.com/heron/heron_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_robot` to `0.1.7-2`:

- upstream repository: https://github.com/heron/heron_robot.git
- release repository: https://github.com/clearpath-gbp/heron_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.7-1`

## heron_base

```
* Fix bugs related to the switch to CV5 (#11 <https://github.com/heron/heron_robot/issues/11>)
  * Use relays instead of remap; remap doesn't work in an include.  Add additional necessary dependencies
  * Set the IMU to operate in ENU mode instead of the default NED
  * Rename the microstrain nodes to use "imu" instead of "cv5" to be more universal
* Contributors: Chris I-B
```

## heron_bringup

- No changes

## heron_nmea

- No changes

## heron_robot

```
* Fix bugs related to the switch to CV5 (#11 <https://github.com/heron/heron_robot/issues/11>)
  * Use relays instead of remap; remap doesn't work in an include.  Add additional necessary dependencies
  * Set the IMU to operate in ENU mode instead of the default NED
  * Rename the microstrain nodes to use "imu" instead of "cv5" to be more universal
* Contributors: Chris I-B
```
