### PR TITLE
cpr_gps_navigation: 0.1.22-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -113,7 +113,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.21-1
+      version: 0.1.22-1
   cpr_gps_tasks:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.22-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.21-1`

## cpr_gps_costmap_layers

- No changes

## cpr_gps_localization

- No changes

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

```
* Merge branch 'log_safety' into 'master'
* Contributors: José Mastrangelo
```

## cpr_gps_path_smoothing

- No changes

## cpr_gps_safety

- No changes
