### PR TITLE
warthog: 0.1.4-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -809,7 +809,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.1.3-1
+      version: 0.1.4-2
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.4-2`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-1`

## warthog_control

- No changes

## warthog_description

```
* CPR extras (#17 <https://github.com/warthog-cpr/warthog/issues/17>)
  * cpr_extras
  * cpr_extras
  * remove cpr_extras.urdf
  Co-authored-by: Ebrahim Shahrivar <mailto:eshahrivar@clearpath.ai>
* Add an envar to set the paint colour of the URDF (#16 <https://github.com/warthog-cpr/warthog/issues/16>)
  * Add the WARTHOG_COLOR envar, with options 'yellow' (default) and 'olive_green'
  * Simplify the paint options, add orange and sand as additional choices based on feedback from sales on the available colours.
* [warthog_description] Added generator accessory.
* Contributors: Chris I-B, Ebrahim Shahrivar, Tony Baltovski
```

## warthog_msgs

- No changes
