### PR TITLE
warthog_robot: 0.1.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -843,7 +843,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_robot` to `0.1.5-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.4-1`

## warthog_base

```
* Only update joint states when the robot is not e-stopped
* [warthog_base] Added topic relay to command MCU to go into low power mode.
* [warthog_robot] Remove unused RC teleo-op.
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## warthog_bringup

- No changes

## warthog_robot

- No changes
