### PR TITLE
husky: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12,6 +12,33 @@ repositories:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/firmware_components-gbp.git
       version: 2.9.5-1
+  husky:
+    doc:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: noetic-devel
+    release:
+      packages:
+      - husky_base
+      - husky_bringup
+      - husky_control
+      - husky_description
+      - husky_desktop
+      - husky_gazebo
+      - husky_msgs
+      - husky_navigation
+      - husky_robot
+      - husky_simulator
+      - husky_viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: noetic-devel
+    status: maintained
   jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.5.0-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## husky_base

- No changes

## husky_bringup

```
* [husky_bringup] Switched microstrain_mips to ros_mscl.
* Fix the python-scipy dependency to refer to the python-3 version; python-scipy isn't installable on Focal
* Fix a bug where the UM7 and UM6 launch files don't work when installed to /etc/ros/*/ros.d; they fail to find the mag config files.
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## husky_control

```
* Disabled multimaster.
* Add the link_name parameter to fix the interactive markers in rviz
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## husky_description

```
* Update husky.urdf.xacro (#169 <https://github.com/husky/husky/issues/169>)
  Fix Failed to build tree: child link [base_laser_mount] of joint [laser_mount_joint] not found error.
  As found on https://answers.ros.org/question/354219/failed-to-build-tree-child-link-base_laser_mount-of-joint-laser_mount_joint-not-found/
* Contributors: Guido Sanchez
```

## husky_desktop

- No changes

## husky_gazebo

```
* Disabled multimaster.
* Update spawn_husky.launch
  I think the robot spawn should be like this
* Contributors: Guido Sanchez, Tony Baltovski
```

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
