### PR TITLE
cpr_gps_navigation: 0.1.23-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -110,10 +110,12 @@ repositories:
       - cpr_gps_navigation_server
       - cpr_gps_path_smoothing
       - cpr_gps_safety
+      - cpr_sbpl_lattice_planner
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.22-1
+      version: 0.1.23-2
+    status: maintained
   cpr_gps_tasks:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.23-2`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.22-1`

## cpr_gps_costmap_layers

- No changes

## cpr_gps_localization

```
* Merge branch 'atomic_thread' into 'master'
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

```
* Merge branch 'atomic_thread' into 'master'
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_gps_path_smoothing

- No changes

## cpr_gps_safety

- No changes

## cpr_sbpl_lattice_planner

```
* Merge branch 'feature/mbf_sbpl' into 'master'
  Feature/mbf sbpl
  See merge request gps-navigation/cpr_gps_navigation!99
* Feature/mbf sbpl
* Contributors: Ebrahim Shahrivar
```
