### PR TITLE
cpr_gps_navigation: 0.1.24-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -114,7 +114,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.23-2
+      version: 0.1.24-1
     status: maintained
   cpr_gps_tasks:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.24-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.23-2`

## cpr_gps_costmap_layers

- No changes

## cpr_gps_localization

- No changes

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

- No changes

## cpr_gps_path_smoothing

- No changes

## cpr_gps_safety

- No changes

## cpr_sbpl_lattice_planner

```
* added mbf_msgs dependency
* Contributors: Jose Mastrangelo
```
