### PR TITLE
husky: 0.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -33,7 +33,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.5.0-2
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.5.1-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.0-2`

## husky_base

```
* Eliminate roslint errors
* Contributors: Lucas Walter, Tony Baltovski
```

## husky_bringup

```
* Fix the name of teh VLP16 launch file that gets included
* Add a missing colon to the install script
* Add VLP16, secondary LMS1xx support (#164 <https://github.com/husky/husky/issues/164>)
  * Minimal refactor to add VLP16 + secondary LMS1xx support. Update defaults for the laser_enabled and realsense_enabled args to refer to the underlying envars to improve consistency when launching simulations. Modify the sensor bar to allow it to be positioned in the center by default, but with configurable xyz and rpy offsets
  * Add the new run dependencies
  * Remove the prefix's trailing underscore in the vlp16 mount to make it consistent. Fix an inconsistent envar for the sensor arch, add an arg to explicitly enable it, to stay internally consistent with the rest of Husky.
  * Fix the envars; its just HUSKY_LMS1XX, not HUSKY_LASER_LMS1XX
  * Revert to enabling the main laser by default in the simulations, add the velodyne_gazebo_plugins dependency
* Contributors: Chris I-B
```

## husky_control

```
* Remove the need to explicitly specify the laser_enabled, realsense_enabled, and urdf_extras arguments; use the envars to make it easier to simulate customized robots & use the moveit setup assistant.
* Contributors: Chris Iverach-Brereton
```

## husky_description

```
* cpr urdf extras
* Remove the need to explicitly specify the laser_enabled, realsense_enabled, and urdf_extras arguments; use the envars to make it easier to simulate customized robots & use the moveit setup assistant.
* Update intel_realsense.urdf.xacro
  modify image format in sim to avoid log warn spam
* Add HUSKY_{FRONT|REAR}_BUMPER envars we can use to completely turn off the front & rear bumpers.  This is requested to make integration of the wireless charging docks easier
* Add VLP16, secondary LMS1xx support (#164 <https://github.com/husky/husky/issues/164>)
  * Minimal refactor to add VLP16 + secondary LMS1xx support. Update defaults for the laser_enabled and realsense_enabled args to refer to the underlying envars to improve consistency when launching simulations. Modify the sensor bar to allow it to be positioned in the center by default, but with configurable xyz and rpy offsets
  * Add the new run dependencies
  * Remove the prefix's trailing underscore in the vlp16 mount to make it consistent. Fix an inconsistent envar for the sensor arch, add an arg to explicitly enable it, to stay internally consistent with the rest of Husky.
  * Fix the envars; its just HUSKY_LMS1XX, not HUSKY_LASER_LMS1XX
  * Revert to enabling the main laser by default in the simulations, add the velodyne_gazebo_plugins dependency
* Add the ability to add the sensor bar with an envar without adding the realsense.  Add the sensor bar height as another arg + envar, fix the URDF when the 300mm sensorbar is enabled.
* Contributors: Chris I-B, Ebrahim Shahrivar, vamshi konduri
```

## husky_desktop

- No changes

## husky_gazebo

```
* Remove the need to explicitly specify the laser_enabled, realsense_enabled, and urdf_extras arguments; use the envars to make it easier to simulate customized robots & use the moveit setup assistant.
* Add VLP16, secondary LMS1xx support (#164 <https://github.com/husky/husky/issues/164>)
  * Minimal refactor to add VLP16 + secondary LMS1xx support. Update defaults for the laser_enabled and realsense_enabled args to refer to the underlying envars to improve consistency when launching simulations. Modify the sensor bar to allow it to be positioned in the center by default, but with configurable xyz and rpy offsets
  * Add the new run dependencies
  * Remove the prefix's trailing underscore in the vlp16 mount to make it consistent. Fix an inconsistent envar for the sensor arch, add an arg to explicitly enable it, to stay internally consistent with the rest of Husky.
  * Fix the envars; its just HUSKY_LMS1XX, not HUSKY_LASER_LMS1XX
  * Revert to enabling the main laser by default in the simulations, add the velodyne_gazebo_plugins dependency
* Contributors: Chris I-B, Chris Iverach-Brereton
```

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

```
* Remove the need to explicitly specify the laser_enabled, realsense_enabled, and urdf_extras arguments; use the envars to make it easier to simulate customized robots & use the moveit setup assistant.
* Add VLP16, secondary LMS1xx support (#164 <https://github.com/husky/husky/issues/164>)
  * Minimal refactor to add VLP16 + secondary LMS1xx support. Update defaults for the laser_enabled and realsense_enabled args to refer to the underlying envars to improve consistency when launching simulations. Modify the sensor bar to allow it to be positioned in the center by default, but with configurable xyz and rpy offsets
  * Add the new run dependencies
  * Remove the prefix's trailing underscore in the vlp16 mount to make it consistent. Fix an inconsistent envar for the sensor arch, add an arg to explicitly enable it, to stay internally consistent with the rest of Husky.
  * Fix the envars; its just HUSKY_LMS1XX, not HUSKY_LASER_LMS1XX
  * Revert to enabling the main laser by default in the simulations, add the velodyne_gazebo_plugins dependency
* Contributors: Chris I-B
```
