### PR TITLE
cpr_gps_common: 0.1.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -93,13 +93,14 @@ repositories:
       - cpr_gps_common
       - cpr_gps_navigation_msgs
       - cpr_pointcloud_filter
+      - cpr_robot_indicators
       - cpr_std_srvs
       - nav_core_cpr
       - nav_utils
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
-      version: 0.1.10-1
+      version: 0.1.11-1
   cpr_gps_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.11-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.10-1`

## cpr_robot_indicators

```
* Merge branch 'led_indicators' into 'master'
  Led indicators package
  See merge request gps-navigation/cpr_gps_common!24
* Led indicators package
* Contributors: Ebrahim Shahrivar
```
