### PR TITLE
cpr_gps_common: 0.1.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -100,7 +100,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
-      version: 0.1.11-1
+      version: 0.1.12-1
   cpr_gps_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.12-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.11-1`

## autonomy_msgs

- No changes

## autonomy_msgs_utils

- No changes

## cpr_autonomy_metrics

- No changes

## cpr_diagnostics

- No changes

## cpr_estop_monitor

- No changes

## cpr_geodetic_survey

- No changes

## cpr_gps_common

- No changes

## cpr_gps_navigation_msgs

- No changes

## cpr_pointcloud_filter

- No changes

## cpr_robot_indicators

```
* fix on the robot
* Contributors: Ebrahim Shahrivar
```

## cpr_std_srvs

- No changes

## nav_core_cpr

- No changes

## nav_utils

- No changes
