### PR TITLE
husky_robot: 0.6.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -36,6 +36,25 @@ repositories:
       url: https://github.com/husky/husky.git
       version: noetic-devel
     status: maintained
+  husky_robot:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_robot.git
+      version: noetic-devel
+    release:
+      packages:
+      - husky_base
+      - husky_bringup
+      - husky_robot
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_robot-release.git
+      version: 0.6.0-2
+    source:
+      type: git
+      url: https://github.com/husky/husky_robot.git
+      version: noetic-devel
+    status: maintained
   jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.6.0-2`:

- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## husky_base

```
* Re-added husky_robot from husky.
* Contributors: Tony Baltovski
```

## husky_bringup

```
* Re-added husky_robot from husky.
* Contributors: Tony Baltovski
```

## husky_robot

```
* Re-added husky_robot from husky.
* Contributors: Tony Baltovski
```
