### PR TITLE
jackal_robot: 0.6.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -495,7 +495,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.6.3-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.2-1`

## jackal_base

```
* Merge pull request #33 <https://github.com/jackal/jackal_robot/issues/33> from ms-iot/init_windows
  Fix Windows build
* Fix Windows build
* 0.6.2
* Update the changelogs ahead of release
* Contributors: Chris Iverach-Brereton, Lou Amadio, Tony Baltovski
```

## jackal_bringup

```
* Merge pull request #37 <https://github.com/jackal/jackal_robot/issues/37> from luis-camero/melodic-devel
  Added Velodyne HDL-32E driver launch file to the accessories launch
* Added Velodyne HDL-32E driver launch file to the accessories launch file under environment variable JACKAL_LASER_3D_MODEL=hdl32e
* Add envar support for adding a GX5 family IMU (#34 <https://github.com/jackal/jackal_robot/issues/34>)
  * Launch the GX5 IMU node if necessary
  * Change the name of the frame id arg for the IMU to match with the latest ros_mscl
  * Use the ENU frame instead of NED for the GX5
* Merge pull request #32 <https://github.com/jackal/jackal_robot/issues/32> from jackal/rsci-227
  Set fender lidar angle range
* Set the max/min angles for the fender lidars to [-pi, pi] to prevent the sensors from seeing the wheels/chassis.  If the robot sees its own wheels it can cause problems with ARK, which is the main use-case for the fender lasers.
* 0.6.2
* Update the changelogs ahead of release
* Fix the name of the VLP16 launch file that gets included in accessories
* Fix a c&p error where and arg was referenced before it was actually assigned
* Contributors: Chris I-B, Chris Iverach-Brereton, Luis Camero, Tony Baltovski
```

## jackal_robot

```
* 0.6.2
* Update the changelogs ahead of release
* Contributors: Chris Iverach-Brereton
```
