### PR TITLE
dingo_robot: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -200,7 +200,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.1.4-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-1`

## dingo_base

- No changes

## dingo_bringup

```
* Setup scripts to automatically set DINGO_OMNI and DINGO_WIRELESS_INTERFACE envars (#8 <https://github.com/dingo-cpr/dingo_robot/issues/8>)
  * Automatically triggering setup scripts in post_install()
  * Add wireless interface and dingo config scripts
  * Find setup scripts using find_in_workspaces, and trigger automatically
  * Fix script names
  Co-authored-by: Joey Yang <mailto:jyang@clearpathrobotics.com>
* Fix the name of teh VLP16 launch file that gets included
* Contributors: Chris Iverach-Brereton, jyang-cpr
```

## dingo_robot

- No changes
