### PR TITLE
jackal: 0.8.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -70,11 +70,12 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.8.0-1
+      version: 0.8.0-2
     source:
       type: git
       url: https://github.com/jackal/jackal.git
       version: noetic-devel
+    status: maintained
   jackal_desktop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.0-2`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.0-1`

## jackal_control

```
* Merge branch 'noetic-devel-bkup' into noetic-devel
* Fix the link_name parameter for the interactive marker server; the default for the package includes a leading '/', which prevents the markers from working on Noetic.  We can revert this if/when the default for interactive_marker_twist_server is modified.
* Contributors: Chris Iverach-Brereton
```

## jackal_description

- No changes

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
