### PR TITLE
husky_gps_navigation: 0.1.4-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -426,6 +426,13 @@ repositories:
       url: https://github.com/husky/husky_cartographer_navigation.git
       version: melodic-devel
     status: developed
+  husky_gps_navigation:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/husky_gps_navigation-gbp.git
+      version: 0.1.4-2
+    status: maintained
   image_undistort:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_gps_navigation` to `0.1.4-2`:

- upstream repository: http://gitlab.clearpathrobotics.com/gps-navigation/husky_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/husky_gps_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## husky_gps_navigation

```
* Contributors: Ebrahim Shahrivar, Jose Mastrangelo, José Mastrangelo
```
