### PR TITLE
jackal_gps_navigation: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -495,6 +495,13 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git
       version: indigo-devel
     status: maintained
+  jackal_gps_navigation:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/jackal_gps_navigation-gbp.git
+      version: 0.1.4-1
+    status: maintained
   jackal_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_gps_navigation` to `0.1.4-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/gps-navigation/jackal_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_gps_navigation-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jackal_gps_navigation

```
* Contributors: José Mastrangelo
```
