### PR TITLE
husky: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6,6 +6,28 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  husky:
+    doc:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: foxy-devel
+    release:
+      packages:
+      - husky_base
+      - husky_control
+      - husky_description
+      - husky_gazebo
+      - husky_msgs
+      - husky_viz
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: foxy-devel
+    status: developed
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `1.0.0-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## husky_base

```
* Initial Gazebo Classic changes.
* Updates to use ros2_control.
* [husky_base] Fixed comparison warnings.
* [husky_base] Fixed logging variable order.
* [husky_base] Populated hardware states and removed joints struct.
* Initial attempt at ros2_control.
* [husky_base] Updated horizon_legacy library for C++11.
* [husky_base] Linting changes to horizon_legacy library.
* Contributors: Tony Baltovski
```

## husky_control

```
* Initial Gazebo Classic changes.
* [husky_control] Added basic localization config.
* [husky_control] Disabled interactive_marker_twist_server for now.
* Removed missing packages in ROS2.
* [husky_control] Removed multimaster_launch.
* [husky_control] Added teleop launch.
* [husky_control] Update control rate to 10Hz.
* Updates to use ros2_control.
* [husky_control] Updated CMakeLists.txt.
* Initial attempt at ros2_control.
* Add the link_name parameter to fix the interactive markers in rviz
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## husky_description

```
* Initial Gazebo Classic changes.
* [husky_description] Updated serial port.
* Updates to use ros2_control.
* Initial attempt at ros2_control.
* Update husky.urdf.xacro (#169 <https://github.com/husky/husky/issues/169>)
  Fix Failed to build tree: child link [base_laser_mount] of joint [laser_mount_joint] not found error.
  As found on https://answers.ros.org/question/354219/failed-to-build-tree-child-link-base_laser_mount-of-joint-laser_mount_joint-not-found/
* Contributors: Guido Sanchez, Tony Baltovski
```

## husky_gazebo

```
* Initial Gazebo Classic changes.
* Added COLCON_IGNORE for certian packages.
* Contributors: Tony Baltovski
```

## husky_msgs

```
* [husky_msgs] Updated husky_msgs for ROS2.
* Contributors: Tony Baltovski
```

## husky_viz

```
* [husky_viz] Removed tests.
* [husky_viz] Switched to depend on rviz2.
* Removed missing packages in ROS2.
* Updates to use ros2_control.
* Added COLCON_IGNORE for certian packages.
* Contributors: Tony Baltovski
```
