### PR TITLE
husky: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -16,13 +16,16 @@ repositories:
       - husky_base
       - husky_control
       - husky_description
+      - husky_desktop
       - husky_gazebo
       - husky_msgs
+      - husky_robot
+      - husky_simulator
       - husky_viz
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 1.0.0-2
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `1.0.1-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-2`

## husky_base

- No changes

## husky_control

- No changes

## husky_description

```
* [husky_description] Removed testing.
* Contributors: Tony Baltovski
```

## husky_desktop

```
* Bumped verisons of metapackages.
* Re-enabled metapackages.
* Contributors: Tony Baltovski
```

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_robot

```
* Bumped verisons of metapackages.
* [husky_robot] Disabled dependency on husky_bringup.
* Re-enabled metapackages.
* Contributors: Tony Baltovski
```

## husky_simulator

```
* Bumped verisons of metapackages.
* Re-enabled metapackages.
* Contributors: Tony Baltovski
```

## husky_viz

- No changes
