### PR TITLE
ros_mscl: 1.2.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -172,7 +172,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ros_mscl-release.git
-      version: 1.2.7-3
+      version: 1.2.9-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ros_mscl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mscl` to `1.2.9-1`:

- upstream repository: https://github.com/clearpathrobotics/ros_mscl.git
- release repository: https://github.com/clearpath-gbp/ros_mscl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.7-3`

## mscl_msgs

- No changes

## ros_mscl

```
* Add a polling loop to wait for the serial device to actually exist on-disk before opening it
* Contributors: Chris Iverach-Brereton
```
