### PR TITLE
camera_info_manager_py: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,6 +6,13 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  camera_info_manager_py:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/camera_info_manager_py-release.git
+      version: 0.3.1-1
+    status: maintained
   firmware_components:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py` to `0.3.1-1`:

- upstream repository: https://github.com/clearpathrobotics/camera_info_manager_py.git
- release repository: https://github.com/clearpath-gbp/camera_info_manager_py-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## camera_info_manager_py

```
* changelog
* Contributors: José Mastrangelo
```
