### PR TITLE
acado: 1.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,6 +6,13 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  acado:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/acado-release.git
+      version: 1.3.0-1
+    status: maintained
   camera_info_manager_py:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/acado.git
- release repository: https://github.com/clearpath-gbp/acado-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## acado

```
* Merge pull request #5 <https://github.com/clearpathrobotics/acado/issues/5> from jmastrangelo-cpr/tudelft-stable
  Tudelft stable (melodic release)
* Contributors: Andres, Joachim Ferreau, Jonathan Jekir, Milan Vukov, Olzhas Adiyatov, Rafael Saback, Rien Quirynen, Ronald Ensing, Shahab Kaynama, Torstein I. Bø, Torstein Ingebrigtsen Bø, andrea.zanelli, jmastrangelo-cpr, nielsvd, rienq
```
