### PR TITLE
microhard_snmp: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -174,6 +174,13 @@ repositories:
       url: https://github.com/clearpathrobotics/lockmount_description.git
       version: main
     status: maintained
+  microhard_snmp:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
+      version: 0.0.2-1
+    status: maintained
   ros_mscl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microhard_snmp` to `0.0.2-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/microhard_snmp.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## microhard_snmp

```
* changes for Noetic release
* Contributors: Ebrahim, José Mastrangelo
```
