### PR TITLE
Add ROS2 dependencies needed by Boxer

### DIFF
--- a/rosdep/noetic.yaml
+++ b/rosdep/noetic.yaml
@@ -2,3 +2,11 @@ firmware_components:
   ubuntu: ros-noetic-firmware-components
 libmscl:
   ubuntu: c++-mscl
+
+# ROS2 dependencies needed for Boxer 2.4
+foxy_ros_base:
+  ubuntu: ros-foxy-ros-base
+foxy_ros1_bridge:
+  ubuntu: ros-foxy-ros1-bridge
+foxy_rmw_cyclonedds_cpp:
+  ubuntu: ros-foxy-rmw-cyclonedds-cpp

--- a/rosdep/noetic.yaml
+++ b/rosdep/noetic.yaml
@@ -1,3 +1,5 @@
+clearpath_api:
+  ubuntu: clearpath-api
 firmware_components:
   ubuntu: ros-noetic-firmware-components
 libmscl:


### PR DESCRIPTION
Add ROS2/Foxy dependencies needed by boxer_bringup and boxer_base to interact with Otto's ROS2 API

There may be a nicer way to do this, but if there is I'm not aware of it.