### PR TITLE
axis_camera: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13,6 +13,21 @@ repositories:
       url: https://github.com/clearpath-gbp/acado-release.git
       version: 1.3.0-1
     status: maintained
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/axis_camera-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: noetic-devel
+    status: maintained
   camera_info_manager_py:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.4.0-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## axis_camera

```
* upgraded cmakelist and package.xml, and setup.py for noetic (#70 <https://github.com/ros-drivers/axis_camera/issues/70>)
* Update the python files to be python-3 compliant.  Fix some bugs in the image data parsing needed as part of this update
* Merge pull request #55 <https://github.com/ros-drivers/axis_camera/issues/55> from sgemme-csa/master
  KeyError in publishCameraState when camera is not ready on PTZ camera
* Merge branch 'master' of github.com:ros-drivers/axis_camera
* Expose the height & width parameters as arguments in the launch file
* Merge pull request #56 <https://github.com/ros-drivers/axis_camera/issues/56> from jeff-o/patch-1
  Update axis.launch
* Revert "Fix up the main scripts to be python-3 compliant"
  This reverts commit 569e4b22415edee653914fa387a689d2e85e2879.
* Fix up the main scripts to be python-3 compliant
* Merge branch 'master' of github.com:ros-drivers/axis_camera
* Merge pull request #58 <https://github.com/ros-drivers/axis_camera/issues/58> from luishowell/master
  add support for quad video
* Merge pull request #61 <https://github.com/ros-drivers/axis_camera/issues/61> from cclauss/patch-1
  Fix Python 3 syntax error
* Remove the html_static directory from conf.py; it doesn't exist anyway and is just creating a warning that's causing Jenkins to see the build as unstable
* Fix Python 3 syntax error
  #52 <https://github.com/ros-drivers/axis_camera/issues/52> again
* Remove the :: leftover from the .rst
* Copy the README contents to the .md so they show up on the github main page
* Update the maintainer now that Clearpath is officially maintaining this package again
* Merge pull request #54 <https://github.com/ros-drivers/axis_camera/issues/54> from k-okada/add_travis
  update travis.yml
* update travis.yml
* add support for quad video
* Update axis.launch
  Adds the "camera" param to the launch file. Helps launch the driver cleanly when used with other drivers that also use "camera" as a param name.
* No need to close connection as it will get garbage collected
* Merge remote-tracking branch 'csa/develop' into github-master
* Adjusting error message on KeyError
* Merge remote-tracking branch 'github/master' into develop
* Merge branch 'develop' of git+ssh://liberty/data/git/ros/axis_camera into develop
* Fixing camera telemetry where accessing its telemetry before a certain time after startup would causes a KeyError because the fields in the response were not present. Now catching the KeyError exception to fix the problem.
* Fixing camera telemetry where accessing its telemetr before a certain time after startup would cause a KeyError because the fiels in the response were not present, now catchin the KeyError exception to fix the problem
* Fixing connection problem which was causing the telemetry to stall
* Contributors: Chris I-B, Christian Clauss, Howell, Jeff Schmidt, Kei Okada, Sebastien Gemme, jmastrangelo-cpr
```
