### PR TITLE
boxer_desktop: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -46,6 +46,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boxer-cpr/boxer.git
+      version: noetic-devel
     status: maintained
   boxer_desktop:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -28,6 +28,24 @@ repositories:
       url: https://github.com/ros-drivers/axis_camera.git
       version: noetic-devel
     status: maintained
+  boxer_desktop:
+    doc:
+      type: git
+      url: https://github.com/boxer-cpr/boxer_desktop.git
+      version: noetic-devel
+    release:
+      packages:
+      - boxer_desktop
+      - boxer_viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/boxer_desktop-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/boxer-cpr/boxer_desktop.git
+      version: noetic-devel
+    status: maintained
   camera_info_manager_py:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_desktop` to `0.1.1-1`:

- upstream repository: https://github.com/boxer-cpr/boxer_desktop.git
- release repository: https://github.com/clearpath-gbp/boxer_desktop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## boxer_desktop

- No changes

## boxer_viz

- No changes
