### PR TITLE
boxer_simulator: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -28,6 +28,24 @@ repositories:
       url: https://github.com/ros-drivers/axis_camera.git
       version: noetic-devel
     status: maintained
+  boxer_simulator:
+    doc:
+      type: git
+      url: https://github.com/boxer-cpr/boxer_simulator.git
+      version: noetic-devel
+    release:
+      packages:
+      - boxer_gazebo
+      - boxer_simulator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/boxer_simulator-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/boxer-cpr/boxer_simulator.git
+      version: noetic-devel
+    status: maintained
   camera_info_manager_py:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_simulator` to `0.1.1-1`:

- upstream repository: https://github.com/boxer-cpr/boxer_simulator.git
- release repository: https://github.com/clearpath-gbp/boxer_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## boxer_gazebo

```
* Rename BOXER_SERIAL_NO to ROS_ROBOT_SERIAL_NO to match with incoming changes to the ISO
* Contributors: Chris Iverach-Brereton
```

## boxer_simulator

- No changes
