### PR TITLE
husky: 1.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -25,7 +25,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 1.0.1-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `1.0.3-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## husky_base

```
* [husky_base] Switched Boost static assert to C++ standard library.
* Contributors: Tony Baltovski
```

## husky_control

- No changes

## husky_description

- No changes

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
