### PR TITLE
boxer_robot: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -66,6 +66,25 @@ repositories:
       url: https://github.com/boxer-cpr/boxer_desktop.git
       version: noetic-devel
     status: maintained
+  boxer_robot:
+    doc:
+      type: git
+      url: https://github.com/boxer-cpr/boxer_robot.git
+      version: noetic-devel
+    release:
+      packages:
+      - boxer_base
+      - boxer_bringup
+      - boxer_robot
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/boxer_robot-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/boxer-cpr/boxer_robot.git
+      version: noetic-devel
+    status: maintained
   boxer_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.1.1-1`:

- upstream repository: https://github.com/boxer-cpr/boxer_robot.git
- release repository: https://github.com/clearpath-gbp/boxer_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## boxer_base

```
* Add the ROS2 and clearpath_api dependencies for the bridge
* Sort the dependencies
* Only try sourcing the ROS2 API if the directory exists
* Dynamically load the correct ROS2 path when starting the bridges
* Remove a duplicate diagnostic analyzer node
* Remove an unsatisfiable dependency
* Add the IMU filter dependency
* Rename BOXER_SERIAL_NO to ROS_ROBOT_SERIAL_NO to match with incoming changes to the ISO
* Update the build instructions to remove unneeded dependencies, update the actual dependencies
* Teleop is now part of control.launch, so no need to start it separately
* Make all of the scripts executable.  In the export from the previous repository their permissions got mangled
* Contributors: Chris Iverach-Brereton
```

## boxer_bringup

```
* Make all of the scripts executable.  In the export from the previous repository their permissions got mangled
* Contributors: Chris Iverach-Brereton
```

## boxer_robot

- No changes
