### PR TITLE
boxer_desktop: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -60,7 +60,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/boxer_desktop-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/boxer-cpr/boxer_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_desktop` to `0.1.2-1`:

- upstream repository: https://github.com/boxer-cpr/boxer_desktop.git
- release repository: https://github.com/clearpath-gbp/boxer_desktop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## boxer_desktop

- No changes

## boxer_viz

```
* Add a missing rosdep
* Contributors: Chris Iverach-Brereton
```
