### PR TITLE
boxer_robot: 0.1.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -79,7 +79,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/boxer_robot-release.git
-      version: 0.1.3-1
+      version: 0.1.3-2
     source:
       type: git
       url: https://github.com/boxer-cpr/boxer_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.1.3-2`:

- upstream repository: https://github.com/boxer-cpr/boxer_robot.git
- release repository: https://github.com/clearpath-gbp/boxer_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-1`

## boxer_base

```
* Remove the roslint tests; we've removed the source code that would otherwise need linting
* Contributors: Chris Iverach-Brereton
```

## boxer_bringup

- No changes

## boxer_robot

- No changes
