### PR TITLE
boxer_simulator: 0.1.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -97,7 +97,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/boxer_simulator-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/boxer-cpr/boxer_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_simulator` to `0.1.1-2`:

- upstream repository: https://github.com/boxer-cpr/boxer_simulator.git
- release repository: https://github.com/clearpath-gbp/boxer_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## boxer_gazebo

```
* Rename BOXER_SERIAL_NO to ROS_ROBOT_SERIAL_NO to match with incoming changes to the ISO
* Contributors: Chris Iverach-Brereton
```

## boxer_simulator

- No changes
