### PR TITLE
boxer_robot: 0.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -79,7 +79,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/boxer_robot-release.git
-      version: 0.1.3-2
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/boxer-cpr/boxer_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.1.4-1`:

- upstream repository: https://github.com/boxer-cpr/boxer_robot.git
- release repository: https://github.com/clearpath-gbp/boxer_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-2`

## boxer_base

```
* Install the bridge scripts to the package's /share folder too; otherwise the install & start-bridge scripts won't work correctly
* Contributors: Chris Iverach-Brereton
```

## boxer_bringup

- No changes

## boxer_robot

- No changes
