### PR TITLE
launch_delay: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -249,6 +249,13 @@ repositories:
       url: https://github.com/jackal/jackal_simulator.git
       version: melodic-devel
     status: developed
+  launch_delay:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/launch_delay-gbp.git
+      version: 0.1.0-1
+    status: maintained
   lockmount_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_delay` to `0.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/launch_delay.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/launch_delay-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## launch_delay

```
* Fixed README to augment job rather then replace.
* Minor changes to release this.
* README.md edited online with Bitbucket
* README.md edited online with Bitbucket
* README.md edited online with Bitbucket
* Made script executable.
* package.xml created online with Bitbucket
* CMakeLists.txt created online with Bitbucket
* launch_delay.sh created online with Bitbucket
* delayed_launch.launch created online with Bitbucket
* Initial commit with README.md
* Contributors: Jeff Schmidt, Tony Baltovski, jeff-o
```
