### PR TITLE
earth_rover_piksi: 1.8.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -244,7 +244,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/earth_rover_piksi-release.git
-      version: 1.8.2-1
+      version: 1.8.2-2
     source:
       type: git
       url: https://github.com/earthrover/earth_rover_piksi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `earth_rover_piksi` to `1.8.2-2`:

- upstream repository: https://github.com/earthrover/earth_rover_piksi.git
- release repository: https://github.com/clearpath-gbp/earth_rover_piksi-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.8.2-1`
