### PR TITLE
boxer_robot: 0.1.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -79,7 +79,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/boxer_robot-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/boxer-cpr/boxer_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.1.6-1`:

- upstream repository: https://github.com/boxer-cpr/boxer_robot.git
- release repository: https://github.com/clearpath-gbp/boxer_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.5-1`

## boxer_base

- No changes

## boxer_bringup

```
* Make sure the ros-bridge-start script is marked as executable
* Contributors: Chris Iverach-Brereton
```

## boxer_robot

- No changes
