### PR TITLE
heron_robot: 0.1.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -361,7 +361,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_robot-release.git
-      version: 0.1.7-2
+      version: 0.1.8-1
     source:
       type: git
       url: https://github.com/heron/heron_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_robot` to `0.1.8-1`:

- upstream repository: https://github.com/heron/heron_robot.git
- release repository: https://github.com/clearpath-gbp/heron_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.7-2`

## heron_base

```
* Add support for a HERON_NO_WIRELESS envar to completely disable checking for wireless connectivity; if enabled, just tell the MCU the wireless is fine and suppress the slow-2-pulse
* Change the default IP address for the SNMP check to be the actual address of the base-station.
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## heron_bringup

- No changes

## heron_nmea

- No changes

## heron_robot

- No changes
