### PR TITLE
ridgeback_firmware: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -316,6 +316,21 @@ repositories:
       url: https://github.com/ridgeback/ridgeback.git
       version: melodic-devel
     status: maintained
+  ridgeback_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
+      version: melodic-devel
+    status: maintained
   ros_mscl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_firmware` to `0.2.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ridgeback_firmware

```
* Apply fixes for Melodic+Bionic from Jackal
* Contributors: Chris Iverach-Brereton
```
