### PR TITLE
husky: 0.4.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -406,7 +406,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.4.11-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.10-1`

## husky_base

- No changes

## husky_bringup

```
* Added Hokuyo UST10.
* Fix the compute_calibration script so it uses the correct name for the magnetic field attribute. Fixes https://github.com/husky/husky/issues/182
* Contributors: Chris Iverach-Brereton, Luis Camero
```

## husky_control

```
* Overwrite 'wheel_radius_multiplier' with env. var. HUSKY_WHEEL_MULTIPLIER
* predict odom->base_link tf to current time
* Contributors: Ebrahim Shahrivar, Luis Camero
```

## husky_description

```
* Added UST10 mesh
* Added Hokuyo UST10.
* [husky_description] Fixed malformed STL warning for top_plate.stl.
* Contributors: Luis Camero, Tony Baltovski
```

## husky_desktop

- No changes

## husky_gazebo

```
* Update spawn_husky.launch
  I think the robot spawn should be like this
* Contributors: Guido Sanchez
```

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
