### PR TITLE
ridgeback_robot: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -331,6 +331,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
       version: melodic-devel
     status: maintained
+  ridgeback_robot:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_robot.git
+      version: noetic-devel
+    release:
+      packages:
+      - ridgeback_base
+      - ridgeback_bringup
+      - ridgeback_robot
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_robot.git
+      version: noetic-devel
+    status: maintained
   ros_mscl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.4.0-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ridgeback_base

```
* Update the scipy dependency to Python3
* Contributors: Chris Iverach-Brereton
```

## ridgeback_bringup

- No changes

## ridgeback_robot

- No changes
