### PR TITLE
jackal_desktop: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -481,6 +481,24 @@ repositories:
       url: https://github.com/jackal/jackal_cartographer_navigation.git
       version: melodic-devel
     status: developed
+  jackal_desktop:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: melodic-devel
+    release:
+      packages:
+      - jackal_desktop
+      - jackal_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_desktop-release.git
+      version: 0.4.1-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: melodic-devel
+    status: maintained
   jackal_firmware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_desktop` to `0.4.1-1`:

- upstream repository: https://github.com/jackal/jackal_desktop.git
- release repository: https://github.com/clearpath-gbp/jackal_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## jackal_desktop

- No changes

## jackal_viz

```
* Updated jackal_viz (#3 <https://github.com/jackal/jackal_desktop/issues/3>)
  * Add rqt_gui as run_depend
  * Add rqt directory and launch check
* Diagnostic Viewer (#2 <https://github.com/jackal/jackal_desktop/issues/2>)
  * Added 'view_diagnostics.launch' to start rqt with console and robot monitor
  * Added noetic .perspective, now are dependant on ROS_DISTRO
  * Removed distro specific perspectives
* Contributors: luis-camero
```
