### PR TITLE
dingo: 0.1.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -110,6 +110,26 @@ repositories:
       url: https://github.com/clearpath-gbp/camera_info_manager_py-release.git
       version: 0.3.1-1
     status: maintained
+  dingo:
+    doc:
+      type: git
+      url: https://github.com/dingo-cpr/dingo.git
+      version: melodic-devel
+    release:
+      packages:
+      - dingo_control
+      - dingo_description
+      - dingo_msgs
+      - dingo_navigation
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/dingo-release.git
+      version: 0.1.10-1
+    source:
+      type: git
+      url: https://github.com/dingo-cpr/dingo.git
+      version: melodic-devel
+    status: maintained
   firmware_components:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.10-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dingo_control

```
* set predict_to_current_time
* Contributors: Ebrahim Shahrivar
```

## dingo_description

```
* Add missing "xacro:" infront of "include"
* Contributors: Joey Yang
```

## dingo_msgs

- No changes

## dingo_navigation

- No changes
