### PR TITLE
dingo_robot: 0.1.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -201,7 +201,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.1.5-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.4-1`

## dingo_base

- No changes

## dingo_bringup

```
* Add "_secondary" suffix to secondary laser node
  "RLException: roslaunch file contains multiple nodes named [/hokuyo]." is thrown if primary and secondary lasers are both enabled. This is because both envars launch an instance of the urg_node with the same name "hokuyo". Adding a "_secondary" suffix to the secondary laser node resolves this issue.
* Contributors: jyang-cpr
```

## dingo_robot

```
* Add dependency for dingo_tests
* Contributors: jyang-cpr
```
