### PR TITLE
jackal_robot: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -246,11 +246,12 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.7.0-2
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git
       version: noetic-devel
+    status: maintained
   jackal_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.7.1-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.0-2`

## jackal_base

```
* Fix some ROS lint errors
* Contributors: Chris Iverach-Brereton
```

## jackal_bringup

```
* Removed duplicate Hokuyo fender node launch
* Contributors: luis-camero
```

## jackal_robot

- No changes
