### PR TITLE
dingo_tests: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -148,6 +148,21 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_desktop.git
       version: master
     status: maintained
+  dingo_tests:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/dingo_tests.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/dingo_tests-gbp.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/dingo_tests.git
+      version: noetic-devel
+    status: maintained
   firmware_components:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_tests` to `0.2.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_tests.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_tests-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dingo_tests

```
* Update README.md
* Change raw_input() to input() for Python3/Noetic
* Fix variable name errors
* Fix odometry linear displacement calculation by using magnitude of x and y vector
* Remove shebang for python3 since using catkin_install_python
* Python3 update
* Remove .py extension for ROS node
* Contributors: Joey Yang
```
