### PR TITLE
dingo_robot: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -148,6 +148,25 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_desktop.git
       version: master
     status: maintained
+  dingo_robot:
+    doc:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_robot.git
+      version: noetic-devel
+    release:
+      packages:
+      - dingo_base
+      - dingo_bringup
+      - dingo_robot
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/dingo_robot-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_robot.git
+      version: noetic-devel
+    status: maintained
   dingo_tests:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.2.0-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dingo_base

```
* Update the scipy dependency to python3
* Contributors: Chris Iverach-Brereton
```

## dingo_bringup

- No changes

## dingo_robot

- No changes
