### PR TITLE
yperio: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -532,5 +532,20 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: master
     status: maintained
+  yperio:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/yperio.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/yperio-gbp.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/yperio.git
+      version: main
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `yperio` to `0.1.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/yperio.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/yperio-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## yperio

```
* Removed python3-wstool from dependencies
* Contributors: Luis Camero
```
