### PR TITLE
heron_robot: 0.1.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -361,7 +361,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_robot-release.git
-      version: 0.1.9-1
+      version: 0.1.10-1
     source:
       type: git
       url: https://github.com/heron/heron_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_robot` to `0.1.10-1`:

- upstream repository: https://github.com/heron/heron_robot.git
- release repository: https://github.com/clearpath-gbp/heron_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.9-1`

## heron_base

```
* Refactor the base-station ping check to use a standard ping; the snmp check is consistently failing with our current configurations.
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## heron_bringup

- No changes

## heron_nmea

- No changes

## heron_robot

- No changes
