### PR TITLE
warthog_simulator: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -514,6 +514,24 @@ repositories:
       url: https://github.com/warthog-cpr/warthog_desktop.git
       version: melodic-devel
     status: maintained
+  warthog_simulator:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_simulator.git
+      version: melodic-devel
+    release:
+      packages:
+      - warthog_gazebo
+      - warthog_simulator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog_simulator-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_simulator.git
+      version: melodic-devel
+    status: maintained
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_simulator` to `0.2.2-1`:

- upstream repository: https://github.com/warthog-cpr/warthog_simulator.git
- release repository: https://github.com/clearpath-gbp/warthog_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warthog_gazebo

```
* Use the new arg added in warthog_control to always enable the game controller input when using Gazebo.
* Contributors: Chris Iverach-Brereton
```

## warthog_simulator

- No changes
