### PR TITLE
dingo_simulator: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -167,6 +167,24 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_robot.git
       version: noetic-devel
     status: maintained
+  dingo_simulator:
+    doc:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_simulator.git
+      version: master
+    release:
+      packages:
+      - dingo_gazebo
+      - dingo_simulator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/dingo_simulator-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_simulator.git
+      version: master
+    status: maintained
   dingo_tests:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_simulator` to `0.1.1-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_simulator.git
- release repository: https://github.com/clearpath-gbp/dingo_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dingo_gazebo

```
* Remove the realsense-to-laser node, as it's been axed from the core robot_bringup too
* Add an accessories folder for launching additional nodes that would be part of the bringup on a real robot.  Currently populated with the corresponding realsense nodes from dingo_robot
* Enable passing the config argument to dingo_description
* Contributors: Chris Iverach-Brereton
```

## dingo_simulator

- No changes
