### PR TITLE
ridgeback_firmware: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -434,7 +434,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_firmware` to `0.3.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/ridgeback_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/ridgeback_firmware-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## ridgeback_firmware

```
* Removed ros_lib and genpy deps.
* Contributors: Tony Baltovski
```
