### PR TITLE
husky: 0.6.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -224,7 +224,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.6.2-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.1-1`

## husky_control

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## husky_description

```
* Added Wibotic mesh and STL
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Luis Camero, Tony Baltovski
```

## husky_desktop

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## husky_gazebo

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## husky_msgs

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## husky_navigation

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## husky_simulator

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## husky_viz

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```
