### PR TITLE
husky_robot: 0.6.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -243,7 +243,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.6.2-1`:

- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.1-1`

## husky_base

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## husky_bringup

```
* Removed HUSKY_IMU_LINK since it can be strictly imu_link
* Removed udev rules from bringup package
* Removed references to microstrain_mips, now use ros_mscl
* Bump CMake version to avoid CMP0048 warning.
* Remove unnecessary PS4, Logitech udev rules.
  These were previously removed from Melodic; not sure why they were re-added for Noetic, but I suspect it was a copy-paste error
* Contributors: Chris I-B, Luis Camero, Tony Baltovski
```

## husky_robot

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```
