### PR TITLE
jackal_robot: 0.7.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -316,7 +316,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.7.2-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.1-1`

## jackal_base

```
* Add diagnostic analyzers for EKF localization and twist mux
* Contributors: Luis Camero
```

## jackal_bringup

```
* Updated Microstrain environment variables
* Added GX5 to jackal bringup
* Contributors: Luis Camero
```

## jackal_robot

- No changes
