### PR TITLE
canfestival_ros: 0.10.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -110,6 +110,21 @@ repositories:
       url: https://github.com/clearpath-gbp/camera_info_manager_py-release.git
       version: 0.3.1-1
     status: maintained
+  canfestival_ros:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
+      version: 0.10.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
+      version: noetic-devel
+    status: maintained
   dingo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canfestival_ros` to `0.10.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## canfestival_ros

```
* CORE-16828: Python rosbag errors out when reading base bag
* CORE-16658: Create or fix i18n keys for diagnostics
* Adding missing include for uint8_t definition
* C++11-isms
* Add back canfestival-objdictedit as exec_depend.
* roslint to test_depend.
* Initialize parent struct instead of using memcpy.
* Bump min cmake version.
* Drop objdictedit dep.
* Add ROS logging on node change-of-state
* Contributors: Anthony Calandra, Jeffrey Gorchynski, Mike Purvis
```
