### PR TITLE
sevcon_ros: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -518,6 +518,24 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/serial-release.git
       version: 1.2.1-1
+  sevcon_ros:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: noetic-devel
+    release:
+      packages:
+      - sevcon_ros
+      - sevcon_traction
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: noetic-devel
+    status: maintained
   um6:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `0.2.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sevcon_ros

- No changes

## sevcon_traction

```
* C++11 changes following API change in canfestival_ros; update NodeStates to NodeState; explicitly cast NodeState enum class to integer type
* Explicitly build objdictgen using Python2 for Noetic
* Contributors: Joey Yang
```
