### PR TITLE
warthog_robot: 0.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -585,6 +585,25 @@ repositories:
       url: https://github.com/warthog-cpr/warthog_desktop.git
       version: melodic-devel
     status: maintained
+  warthog_robot:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - warthog_base
+      - warthog_bringup
+      - warthog_robot
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
+      version: 0.1.5-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
+      version: kinetic-devel
+    status: maintained
   warthog_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_robot` to `0.1.5-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warthog_base

```
* Only update joint states when the robot is not e-stopped
* [warthog_base] Added topic relay to command MCU to go into low power mode.
* [warthog_robot] Remove unused RC teleo-op.
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## warthog_bringup

- No changes

## warthog_robot

- No changes
