### PR TITLE
warthog_robot: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -598,7 +598,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
-      version: 0.1.5-1
+      version: 0.2.0-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_robot` to `0.2.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.5-1`

## warthog_base

- No changes

## warthog_bringup

```
* Added load_peak script to use built-in Linux driver for PEAK can driver.  Also, updated Udev rule.
* Contributors: Tony Baltovski
```

## warthog_robot

- No changes
