### PR TITLE
yperio: 0.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -649,7 +649,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/yperio-gbp.git
-      version: 0.1.1-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/yperio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yperio` to `0.1.4-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/yperio.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/yperio-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## yperio

```
* Updated Jackal microstrain variables and added microstrain to Husky
* Contributors: Luis Camero
```
