### PR TITLE
sevcon_ros: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -530,7 +530,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `0.2.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## sevcon_ros

- No changes

## sevcon_traction

```
* [sevcon_traction] Fixed objdictgen path.
* Contributors: Tony Baltovski
```
