### PR TITLE
cpr_indoornav: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -129,6 +129,25 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
       version: 0.0.4-1
     status: maintained
+  cpr_indoornav:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/cpr-indoornav/cpr_indoornav.git
+      version: melodic-devel
+    release:
+      packages:
+      - cpr_indoornav
+      - cpr_indoornav_msgs
+      - cpr_indoornav_tests
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_indoornav-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/cpr-indoornav/cpr_indoornav.git
+      version: melodic-devel
+    status: developed
   dingo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav` to `0.1.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/cpr-indoornav/cpr_indoornav.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cpr_indoornav

```
* Refactor the package structure, rename packages for clarity
* Contributors: Chris Iverach-Brereton
```

## cpr_indoornav_msgs

- No changes

## cpr_indoornav_tests

```
* Add initial network & ROS tests
* Contributors: Chris Iverach-Brereton
```
