### PR TITLE
cpr_indoornav: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -125,6 +125,24 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
       version: noetic-devel
     status: maintained
+  cpr_indoornav:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/cpr-indoornav/cpr_indoornav.git
+      version: noetic-devel
+    release:
+      packages:
+      - cpr_indoornav
+      - cpr_indoornav_tests
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_indoornav-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/cpr-indoornav/cpr_indoornav.git
+      version: noetic-devel
+    status: developed
   dingo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav` to `0.2.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/cpr-indoornav/cpr_indoornav.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cpr_indoornav

```
* Merge branch 'melodic-devel' into noetic-devel
* Initial release for Noetic
* Contributors: Chris Iverach-Brereton
```

## cpr_indoornav_tests

```
* Merge branch 'melodic-devel' into noetic-devel
* Initial release for Noetic
* Contributors: Chris Iverach-Brereton
```
