### PR TITLE
dingo_tests: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -245,11 +245,20 @@ repositories:
       version: master
     status: developed
   dingo_tests:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/dingo_tests.git
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/dingo_tests-gbp.git
-      version: 0.1.1-1
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/dingo_tests.git
+      version: melodic-devel
+    status: developed
   earth_rover_piksi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_tests` to `0.1.2-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_tests.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_tests-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## dingo_tests

```
* Use ip instead of ifconfig
* Fix print statement in rotateTest(); replace pass with time.sleep() in timeout while loops and add proper returns
  (cherry picked from commit 0ef51e00318d0fa0f798ad64bb3df754d6a8d102)
* Update README.md
* Fix variable name errors
* Fix odometry linear displacement calculation by using magnitude of x and y vector
* Contributors: Joey Yang, jyang-cpr
```
