### PR TITLE
dingo_tests: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -242,7 +242,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/dingo_tests-gbp.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/dingo_tests.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_tests` to `0.2.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_tests.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_tests-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## dingo_tests

```
* Use ip instead of ifconfig
  (cherry picked from commit 715694b2db6e6fef75c1ccea7ea13170a5199a85)
* Fix print statement in rotateTest(); replace pass with time.sleep() in timeout while loops and add proper returns
* Contributors: Joey Yang
```
