### PR TITLE
moose: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -626,7 +626,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/moose-release.git
-      version: 0.1.0-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/moose-cpr/moose.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose` to `0.1.2-1`:

- upstream repository: https://github.com/moose-cpr/moose.git
- release repository: https://github.com/clearpath-gbp/moose-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## moose_control

```
* Move rosparam load outside the joy_teleop ns. (#5 <https://github.com/moose-cpr/moose/issues/5>)
  * Move the joy parameters outside the joy_teleop ns to avoid duplicating the namespace. Resolves https://github.com/moose-cpr/moose/issues/4
  * Move the rosparam load back into the teleop namespace, remove the namespace from the yaml file
* Contributors: Chris I-B
```

## moose_description

- No changes

## moose_msgs

- No changes
