### PR TITLE
jackal: 0.7.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -488,7 +488,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.7.8-1
+      version: 0.7.9-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.7.9-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.8-1`

## jackal_control

```
* Updated Microstrain Environment Variables (#105 <https://github.com/jackal/jackal/issues/105>)
  * Added JACKAL_IMU_MICROSTRAIN environment variable to accessories
  * Updated variables in control.launch
* Contributors: luis-camero
```

## jackal_description

- No changes

## jackal_msgs

- No changes

## jackal_navigation

- No changes
