### PR TITLE
jackal_robot: 0.6.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -562,7 +562,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.6.5-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.4-1`

## jackal_base

- No changes

## jackal_bringup

```
* Updated Microstrain launch to include new variables (#47 <https://github.com/jackal/jackal_robot/issues/47>)
* [jackal_bringup] Removed unnecessary udev rule.
* Contributors: Tony Baltovski, luis-camero
```

## jackal_robot

- No changes
