### PR TITLE
jackal_robot: 0.7.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -364,7 +364,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.7.4-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.3-1`

## jackal_base

- No changes

## jackal_bringup

```
* Use python3 for the install script
  Since removing python-is-python3 from the ISO this script appears to fail on a fresh Noetic install.
* Contributors: Chris I-B
```

## jackal_robot

- No changes
