### PR TITLE
dingo_robot: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -209,7 +209,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.2.1-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## dingo_base

- No changes

## dingo_bringup

```
* [dingo_bringup] Updated install script to explicitly use Python3.
* Switch usage of ifconfig (net-tools) to ip (iproute2) (#12 <https://github.com/dingo-cpr/dingo_robot/issues/12>)
  * Switch usage of ifconfig (net-tools) to ip (iproute2)
  * Remove unnecessary "sudo"
* Contributors: Joey Yang, Tony Baltovski
```

## dingo_robot

- No changes
