### PR TITLE
ridgeback_robot: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -520,7 +520,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.4.1-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## ridgeback_base

- No changes

## ridgeback_bringup

```
* [ridgeback_bringup] Updated install script to explicitly use Python3.
* Change the can-udp-bringup to use ip instead of ifconfig (#35 <https://github.com/ridgeback/ridgeback_robot/issues/35>)
  * Change the can-udp-bringup to use ip instead of ifconfig
  * Fix the txqueue length
  * For consistency stick with "link set can0" and not "link set dev can0"
* Contributors: Chris I-B, Tony Baltovski
```

## ridgeback_robot

- No changes
