### PR TITLE
occupancy_grid_utils: 0.0.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -436,6 +436,13 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
       version: 0.0.2-1
     status: maintained
+  occupancy_grid_utils:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/occupancy_grid_utils-release.git
+      version: 0.0.11-1
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `occupancy_grid_utils` to `0.0.11-1`:

- upstream repository: https://github.com/clearpathrobotics/occupancy_grid_utils
- release repository: https://github.com/clearpath-gbp/occupancy_grid_utils-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## occupancy_grid_utils

```
* Drop signals boost component.
* Contributors: Mike Purvis
```
