### PR TITLE
occupancy_grid_utils: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -441,7 +441,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/occupancy_grid_utils-release.git
-      version: 0.0.11-1
+      version: 0.1.0-1
     status: maintained
   puma_motor_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `occupancy_grid_utils` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/occupancy_grid_utils
- release repository: https://github.com/clearpath-gbp/occupancy_grid_utils-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.11-1`

## occupancy_grid_utils

```
* changes for building in ROS Noetic
* Contributors: José Mastrangelo
```
