### PR TITLE
piksi_rtk_msgs: 1.8.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -443,6 +443,16 @@ repositories:
       url: https://github.com/clearpath-gbp/occupancy_grid_utils-release.git
       version: 0.1.0-1
     status: maintained
+  piksi_rtk_msgs:
+    release:
+      packages:
+      - earth_rover_piksi
+      - piksi_multi_rtk
+      - piksi_rtk_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/earth_rover_piksi-release.git
+      version: 1.8.3-1
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `piksi_rtk_msgs` to `1.8.3-1`:

- upstream repository: https://github.com/eshahrivar-cpr/earth_rover_piksi.git
- release repository: https://github.com/clearpath-gbp/earth_rover_piksi-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## earth_rover_piksi

```
* changelog
* Contributors: Ebrahim Shahrivar
```

## piksi_multi_rtk

```
* changelog
* Contributors: Ebrahim Shahrivar
```

## piksi_rtk_msgs

```
* version
* changelog
* upgrade msgs
* Contributors: Ebrahim Shahrivar
* upgrade msgs to v1.11.0
* Contributors: Ebrahim Shahrivar
```
