### PR TITLE
cpr_gps_common: 0.1.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -125,6 +125,28 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
       version: noetic-devel
     status: maintained
+  cpr_gps_common:
+    release:
+      packages:
+      - autonomy_msgs
+      - autonomy_msgs_utils
+      - cpr_autonomy_metrics
+      - cpr_diagnostics
+      - cpr_estop_monitor
+      - cpr_geodetic_survey
+      - cpr_gps_common
+      - cpr_gps_navigation_msgs
+      - cpr_pointcloud_filter
+      - cpr_robot_indicators
+      - cpr_std_srvs
+      - mission_msgs
+      - nav_core_cpr
+      - nav_utils
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
+      version: 0.1.13-1
+    status: maintained
   cpr_indoornav:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.1.13-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/gps-navigation/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## autonomy_msgs

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## autonomy_msgs_utils

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_autonomy_metrics

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo, Michael Hosmar
```

## cpr_diagnostics

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_estop_monitor

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_geodetic_survey

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_gps_common

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_gps_navigation_msgs

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_pointcloud_filter

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_robot_indicators

```
* Upgrade to ROS Noetic
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_std_srvs

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## mission_msgs

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## nav_core_cpr

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## nav_utils

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```
