### PR TITLE
cpr_gps_navigation: 0.1.31-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -147,6 +147,23 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
       version: 0.1.13-1
     status: maintained
+  cpr_gps_navigation:
+    release:
+      packages:
+      - cpr_gps_costmap_layers
+      - cpr_gps_localization
+      - cpr_gps_navigation
+      - cpr_gps_navigation_client
+      - cpr_gps_navigation_server
+      - cpr_gps_path_smoothing
+      - cpr_gps_safety
+      - cpr_lidar_odometry
+      - cpr_sbpl_lattice_planner
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
+      version: 0.1.31-1
+    status: maintained
   cpr_indoornav:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.1.31-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/gps-navigation/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cpr_gps_costmap_layers

```
* Upgrade to ROS Noetic
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_gps_localization

```
* Upgrade to ROS Noetic
* adde localization monitor for lidar odometry
* Contributors: Ebrahim Shahrivar, José Mastrangelo, Michael Hosmar
```

## cpr_gps_navigation

```
* Upgrade to ROS Noetic
* Added lidar odometry (LOAM)
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_gps_navigation_client

```
* Upgrade to ROS Noetic
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_gps_navigation_server

```
* Upgrade to ROS Noetic
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_gps_path_smoothing

```
* Upgrade to ROS Noetic
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_gps_safety

```
* Upgrade to ROS Noetic
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```

## cpr_lidar_odometry

```
* Upgrade to ROS Noetic
* Added LOAM packages for lidar odometry
* Contributors: Ebrahim Shahrivar, José Mastrangelo, Michael Hosmar
```

## cpr_sbpl_lattice_planner

```
* Upgrade to ROS Noetic
* Contributors: Ebrahim Shahrivar, José Mastrangelo
```
