### PR TITLE
gps_mpc_navigation: 0.1.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -312,6 +312,18 @@ repositories:
       url: https://github.com/ros-drivers/flir_camera_driver.git
       version: noetic-devel
     status: maintained
+  gps_mpc_navigation:
+    release:
+      packages:
+      - cpr_local_planner
+      - cpr_pathtracker
+      - gps_mpc_navigation
+      - grid_library
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
+      version: 0.1.11-1
+    status: maintained
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.1.11-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/gps-navigation/gps_mpc_navigation.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cpr_local_planner

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_pathtracker

```
* Upgrade to ROS Noetic
* path progress now fills to 100% when goal completed
* Contributors: José Mastrangelo, Stephen Phillips
```

## gps_mpc_navigation

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## grid_library

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```
