### PR TITLE
cpr_gps_tasks: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -164,6 +164,17 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
       version: 0.1.31-1
     status: maintained
+  cpr_gps_tasks:
+    release:
+      packages:
+      - cpr_gps_camera_tasks
+      - cpr_gps_generic_tasks
+      - cpr_gps_tasks
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
+      version: 0.0.5-1
+    status: maintained
   cpr_indoornav:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_tasks` to `0.0.5-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/gps-navigation/cpr_gps_tasks.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cpr_gps_camera_tasks

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo, Michael Hosmar
```

## cpr_gps_generic_tasks

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```

## cpr_gps_tasks

```
* Upgrade to ROS Noetic
* Contributors: José Mastrangelo
```
