### PR TITLE
yperio: 0.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -780,7 +780,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/yperio-gbp.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/yperio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yperio` to `0.1.5-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/yperio.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/yperio-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.4-1`

## yperio

```
* Added check to payload confirmatioon
* Removed redundant confirm state
* Fixed 'reset' not having config to reset to
* Added .py extension to TIM551 scripts
* Added platform _parmas, missing in TIM551
* Added Hokuyo UTM30
* Added SICK TIM551
* Fixed typos in default secondary UST10
* Added help commands to all user inputs
* Updated __nonzero__ to __bool__ for Python3
* Added default check function
* Fixed bugs and updated default check
* Added yes option (-y)
* Added new prompt auto completer that takes in payload
* Added 'get_choices' to specify acceptable inputs
* Updated acceptable format to edit list parameter
* Fixed typo that prevented 'reset' and 'default'
* Added quotation marks around export values
* Contributors: Luis Camero
```
