### PR TITLE
warthog_firmware: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -716,6 +716,21 @@ repositories:
       url: https://github.com/warthog-cpr/warthog_desktop.git
       version: melodic-devel
     status: maintained
+  warthog_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
+      version: indigo-devel
+    status: maintained
   warthog_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_firmware` to `0.0.4-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_firmware-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warthog_firmware

```
* Apply fixes from Jackal to compile for Bionic/Melodic
* Contributors: Chris Iverach-Brereton
```
