### PR TITLE
cpr_gps_navigation: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -162,7 +162,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.1.32-1
+      version: 0.2.0-1
     status: maintained
   cpr_gps_tasks:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.2.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/cpr-outdoornav/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.32-1`

## cpr_gps_costmap_layers

- No changes

## cpr_gps_localization

- No changes

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

```
* added missing dynamic_reconfigure dependency
* Contributors: José Mastrangelo
```

## cpr_gps_path_smoothing

- No changes

## cpr_gps_safety

- No changes

## cpr_lidar_odometry

- No changes

## cpr_sbpl_lattice_planner

- No changes
