### PR TITLE
gps_mpc_navigation: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -333,7 +333,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
-      version: 0.1.11-1
+      version: 0.2.0-1
     status: maintained
   husky:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_mpc_navigation` to `0.2.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/cpr-outdoornav/gps_mpc_navigation.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/gps_mpc_navigation-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.11-1`

## cpr_local_planner

- No changes

## cpr_pathtracker

```
* Fixed stop distance issue when larger than local_costmap
* Contributors: José Mastrangelo
```

## gps_mpc_navigation

- No changes

## grid_library

- No changes
