### PR TITLE
Remove cpr_indoornav

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -175,24 +175,6 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
       version: 0.1.0-1
     status: maintained
-  cpr_indoornav:
-    doc:
-      type: git
-      url: https://gitlab.clearpathrobotics.com/cpr-indoornav/cpr_indoornav.git
-      version: noetic-devel
-    release:
-      packages:
-      - cpr_indoornav
-      - cpr_indoornav_tests
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/clearpath-gbp/cpr_indoornav-release.git
-      version: 0.2.0-1
-    source:
-      type: git
-      url: https://gitlab.clearpathrobotics.com/cpr-indoornav/cpr_indoornav.git
-      version: noetic-devel
-    status: developed
   cpr_indoornav_base:
     doc:
       type: git


### PR DESCRIPTION
As part of migrating from Gitlab to Github we're breaking several packages out into their own repos.  This section is not needed as the core cpr_indoornav package has been replaced with cpr_indoornav_base and the _tests package has its own repo (which I'm trying to bloom right now, but hitting an assertion error because of the duplication).