### PR TITLE
cpr_indoornav_tests: 0.3.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -205,6 +205,21 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr-indoornav-jackal.git
       version: noetic-devel
     status: developed
+  cpr_indoornav_tests:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr-indoornav-tests.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_indoornav_tests-release.git
+      version: 0.3.0-2
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr-indoornav-tests.git
+      version: noetic-devel
+    status: developed
   cpr_robot_customizer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_tests` to `0.3.0-2`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-tests.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_tests-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## cpr_indoornav_tests

```
* Initial public release
* Contributors: Chris Iverach-Brereton
```
