### PR TITLE
cpr_indoornav_dingo: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -190,6 +190,21 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr_indoornav_base.git
       version: noetic-devel
     status: developed
+  cpr_indoornav_dingo:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr-indoornav-dingo.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_indoornav_dingo-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr-indoornav-dingo.git
+      version: noetic-devel
+    status: developed
   cpr_indoornav_jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_dingo` to `0.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-dingo.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_dingo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## cpr_indoornav_dingo

```
* Initial public release
* Contributors: Chris Iverach-Brereton
```
