### PR TITLE
cpr_indoornav_husky: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -205,6 +205,21 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr-indoornav-dingo.git
       version: noetic-devel
     status: developed
+  cpr_indoornav_husky:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr-indoornav-husky.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr-indoornav-husky.git
+      version: noetic-devel
+    status: developed
   cpr_indoornav_jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_husky` to `0.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-husky.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## cpr_indoornav_husky

```
* Initial public release
* Contributors: Chris Iverach-Brereton
```
