### PR TITLE
cpr_indoornav_ridgeback: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -235,6 +235,21 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr-indoornav-jackal.git
       version: noetic-devel
     status: developed
+  cpr_indoornav_ridgeback:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr-indoornav-ridgeback.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_indoornav_ridgeback-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr-indoornav-ridgeback.git
+      version: noetic-devel
+    status: developed
   cpr_indoornav_tests:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_ridgeback` to `0.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-ridgeback.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_ridgeback-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## cpr_indoornav_ridgeback

```
* Initial public release
* Contributors: Chris Iverach-Brereton
```
