### PR TITLE
jackal: 0.8.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -465,7 +465,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.4-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.8.3-1`

## jackal_control

```
* Disable absolute yaw in default imu configuration
* Set subst_value=true when loading the control_extras file to allow envar-defined configuration inside the file
* Contributors: Chris I-B, Chris Iverach-Brereton
```

## jackal_description

- No changes

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
