### PR TITLE
cpr_gazebo: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -81,6 +81,28 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_docking-gbp.git
       version: 0.0.9-1
     status: maintained
+  cpr_gazebo:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_gazebo.git
+      version: melodic-devel
+    release:
+      packages:
+      - cpr_agriculture_gazebo
+      - cpr_inspection_gazebo
+      - cpr_obstacle_gazebo
+      - cpr_office_gazebo
+      - cpr_orchard_gazebo
+      - gazebo_race_modules
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_gazebo-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_gazebo.git
+      version: melodic-devel
+    status: maintained
   cpr_gps_common:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gazebo` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_gazebo.git
- release repository: https://github.com/clearpath-gbp/cpr_gazebo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## cpr_agriculture_gazebo

```
* Squashed commit of real-world-coords branch.  Add real-world coordinates to all worlds, including elevation
* Merge pull request #17 <https://github.com/clearpathrobotics/cpr_gazebo/issues/17> from clearpathrobotics/orchard
  Add the Orchard world, change maintainership since Dave left.
* Update the author and maintainer tags
* Add the orchard world, as well as a top-level README for the repo
* Merge pull request #6 <https://github.com/clearpathrobotics/cpr_gazebo/issues/6> from clearpathrobotics/RPSW-510
  Physics and Geometry Fixes
* Added default friction to all collisions
* Hard-coded region
* Launch stack (#5 <https://github.com/clearpathrobotics/cpr_gazebo/issues/5>)
  * Added links.  Button formatting still needs work
  * Updated office launches
* Merge pull request #4 <https://github.com/clearpathrobotics/cpr_gazebo/issues/4> from clearpathrobotics/dingo
  Add Dingo support to the office world
* Fix the launch parameter documentation to include the yaw property. Add the full list of supported platforms to the office world's docs
* Add license files to the docs, add documentation for the race modules
* Add yaw spawn parameters for heron & moose
* Merge branch 'master' of github.com:clearpathrobotics/cpr_gazebo
* Add the ability to specify the robot's initial yaw position
* Merge pull request #1 <https://github.com/clearpathrobotics/cpr_gazebo/issues/1> from civerachb-cpr/heron
  Add support for the Heron in the Inspection World
* Update the docs to include the additional platforms & launch parameters
* Merge branch 'moose' into heron
* Add clouds & blue sky to the agriculture environment
* Add Moose spawns for the larger outdoor environments, remove Heron from the dependencies for the agriculture world since it doesn't feature water
* Merge branch 'master' into heron
* Docs
* Added environment variables for selecting platform.  Makes AWS setup easier
* Added installs in cmake
* This repo is getting giant.  Added an agricultural world with a solar farm and an open space for area coverage
* Contributors: Chris Iverach-Brereton, Dave Niewinski, Tony Baltovski
```

## cpr_inspection_gazebo

```
* Re-add the entire pipeline; it looks in a previous revision a good chunk of it was accidentally deleted
* Squashed commit of real-world-coords branch.  Add real-world coordinates to all worlds, including elevation
* Merge pull request #17 <https://github.com/clearpathrobotics/cpr_gazebo/issues/17> from clearpathrobotics/orchard
  Add the Orchard world, change maintainership since Dave left.
* Update the author and maintainer tags
* Add the orchard world, as well as a top-level README for the repo
* Merge pull request #6 <https://github.com/clearpathrobotics/cpr_gazebo/issues/6> from clearpathrobotics/RPSW-510
  Physics and Geometry Fixes
* Removed water urdf stuff and bonus water mesh i had accidentally added
* Added default friction to all collisions
* Added blocks to bridge ends for smaller platforms
* Hard-coded region
* Launch stack (#5 <https://github.com/clearpathrobotics/cpr_gazebo/issues/5>)
  * Added links.  Button formatting still needs work
  * Updated office launches
* Merge pull request #4 <https://github.com/clearpathrobotics/cpr_gazebo/issues/4> from clearpathrobotics/dingo
  Add Dingo support to the office world
* Fix the launch parameter documentation to include the yaw property. Add the full list of supported platforms to the office world's docs
* Add license files to the docs, add documentation for the race modules
* Add yaw spawn parameters for heron & moose
* Merge branch 'master' of github.com:clearpathrobotics/cpr_gazebo
* Add the ability to specify the robot's initial yaw position
* Merge pull request #1 <https://github.com/clearpathrobotics/cpr_gazebo/issues/1> from civerachb-cpr/heron
  Add support for the Heron in the Inspection World
* Update the docs to include the additional platforms & launch parameters
* Merge branch 'moose' into heron
* Add the Heron image to the list of platforms
* Update the readme to include supported platforms, add the water physics & associated image
* Add Moose spawns for the larger outdoor environments, remove Heron from the dependencies for the agriculture world since it doesn't feature water
* Merge branch 'master' into heron
* Fix a typo
* Add a comment to the heron-spawner to explain why it's ignoring the X and Y arguments
* Overhaul the Inspection world so that it uses the water physics from UUV, add the ability to spawn a Heron
* Docs
* Added environment variables for selecting platform.  Makes AWS setup easier
* Added installs in cmake
* A lot more complete
* Renamed gazebo_race_modules to cpr_race_modules.  Added office and inspections worlds.  New worlds still need clutter added
* Contributors: Chris Iverach-Brereton, Dave Niewinski, Tony Baltovski
```

## cpr_obstacle_gazebo

```
* Add a new, enclosed, indoor world with non-planar ground geometry
* Contributors: Chris Iverach-Brereton
```

## cpr_office_gazebo

```
* Squashed commit of real-world-coords branch.  Add real-world coordinates to all worlds, including elevation
* Merge pull request #17 <https://github.com/clearpathrobotics/cpr_gazebo/issues/17> from clearpathrobotics/orchard
  Add the Orchard world, change maintainership since Dave left.
* Update the author and maintainer tags
* Add the orchard world, as well as a top-level README for the repo
* Merge pull request #6 <https://github.com/clearpathrobotics/cpr_gazebo/issues/6> from clearpathrobotics/RPSW-510
  Physics and Geometry Fixes
* Added default friction to all collisions
* Hard-coded region
* Launch stack (#5 <https://github.com/clearpathrobotics/cpr_gazebo/issues/5>)
  * Added links.  Button formatting still needs work
  * Updated office launches
* Merge pull request #4 <https://github.com/clearpathrobotics/cpr_gazebo/issues/4> from clearpathrobotics/dingo
  Add Dingo support to the office world
* Tidy up the office environment to better-distinguish between the construction & complete worlds
* Fix the launch parameter documentation to include the yaw property. Add the full list of supported platforms to the office world's docs
* Add the Dingo launch file to the office world
* Add license files to the docs, add documentation for the race modules
* Merge branch 'master' of github.com:clearpathrobotics/cpr_gazebo
* Add the ability to specify the robot's initial yaw position
* Merge pull request #1 <https://github.com/clearpathrobotics/cpr_gazebo/issues/1> from civerachb-cpr/heron
  Add support for the Heron in the Inspection World
* Add clouds to the office world
* Merge branch 'master' into heron
* Docs
* Added ridgeback to office world
* Added environment variables for selecting platform.  Makes AWS setup easier
* Added installs in cmake
* A lot more complete
* Renamed gazebo_race_modules to cpr_race_modules.  Added office and inspections worlds.  New worlds still need clutter added
* Contributors: Chris Iverach-Brereton, Dave Niewinski, Tony Baltovski
```

## cpr_orchard_gazebo

```
* Squashed commit of real-world-coords branch.  Add real-world coordinates to all worlds, including elevation
* Merge pull request #17 <https://github.com/clearpathrobotics/cpr_gazebo/issues/17> from clearpathrobotics/orchard
  Add the Orchard world, change maintainership since Dave left.
* Update the author and maintainer tags
* Add the orchard world, as well as a top-level README for the repo
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## gazebo_race_modules

```
* Merge pull request #17 <https://github.com/clearpathrobotics/cpr_gazebo/issues/17> from clearpathrobotics/orchard
  Add the Orchard world, change maintainership since Dave left.
* Update the author and maintainer tags
* Merge pull request #6 <https://github.com/clearpathrobotics/cpr_gazebo/issues/6> from clearpathrobotics/RPSW-510
  Physics and Geometry Fixes
* Added default friction to all collisions
* Add license files to the docs, add documentation for the race modules
* Merge branch 'master' into heron
* Added installs in cmake
* Renamed gazebo_race_modules to cpr_race_modules.  Added office and inspections worlds.  New worlds still need clutter added
* Contributors: Chris Iverach-Brereton, Dave Niewinski, Tony Baltovski
```
