### PR TITLE
cpr_gazebo: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -125,6 +125,28 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
       version: noetic-devel
     status: maintained
+  cpr_gazebo:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_gazebo.git
+      version: noetic-devel
+    release:
+      packages:
+      - cpr_agriculture_gazebo
+      - cpr_inspection_gazebo
+      - cpr_obstacle_gazebo
+      - cpr_office_gazebo
+      - cpr_orchard_gazebo
+      - gazebo_race_modules
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_gazebo-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_gazebo.git
+      version: noetic-devel
+    status: maintained
   cpr_gps_common:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gazebo` to `0.2.1-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_gazebo.git
- release repository: https://github.com/clearpath-gbp/cpr_gazebo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## cpr_agriculture_gazebo

- No changes

## cpr_inspection_gazebo

```
* Disable the water physics; UUV does not appear to be released for Noetic yet. Will re-enable later if possible
* Contributors: Chris Iverach-Brereton
```

## cpr_obstacle_gazebo

- No changes

## cpr_office_gazebo

- No changes

## cpr_orchard_gazebo

- No changes

## gazebo_race_modules

- No changes
