### PR TITLE
cpr_common_msgs: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -125,6 +125,17 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
       version: noetic-devel
     status: maintained
+  cpr_common_msgs:
+    release:
+      packages:
+      - cpr_common_msgs
+      - cpr_common_srvs
+      - gpio_msgs
+      - led_array_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/boxer_gbp/cpr_common_msgs.git
+      version: 0.0.1-1
   cpr_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_common_msgs` to `0.0.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/Boxer/cpr_common_msgs.git
- release repository: http://gitlab.clearpathrobotics.com/boxer_gbp/cpr_common_msgs.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cpr_common_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## cpr_common_srvs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## gpio_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```

## led_array_msgs

```
* Initial ish commit
* Contributors: Dave Niewinski
```
