### PR TITLE
dingo_firmware_components: 2.9.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -351,6 +351,12 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_desktop.git
       version: master
     status: maintained
+  dingo_firmware_components:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware_components.git
+      version: 2.9.12-1
   dingo_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_firmware_components` to `2.9.12-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware_components.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dingo_firmware_components

```
* Fixed merge bin command.
* Contributors: Tony Baltovski
```
