### PR TITLE
dingo_firmware: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -351,6 +351,12 @@ repositories:
       url: https://github.com/dingo-cpr/dingo_desktop.git
       version: master
     status: maintained
+  dingo_firmware:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware-gbp.git
+      version: 0.2.0-1
   dingo_firmware_components:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_firmware` to `0.2.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dingo_firmware

```
* Changes for Noetic.
* 0.1.6
* Changes.
* Fixed merge bin command.
* Contributors: Tony Baltovski
```
