### PR TITLE
cpr_indoornav_base: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -217,7 +217,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_base-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr_indoornav_base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_base` to `0.3.2-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-base.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_base-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.1-1`

## cpr_indoornav_base

```
* Use python3 not python for the tf republisher script
* Contributors: Chris Iverach-Brereton
```
