### PR TITLE
cpr_platform_tests: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -298,6 +298,18 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr-indoornav-tests.git
       version: noetic-devel
     status: developed
+  cpr_platform_tests:
+    release:
+      packages:
+      - dingo_tests
+      - husky_tests
+      - jackal_tests
+      - ridgeback_tests
+      - warthog_tests
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/cpr_platform_tests-gbp.git
+      version: 0.3.0-1
   cpr_robot_customizer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_platform_tests` to `0.3.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/cpr_platform_tests.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/cpr_platform_tests-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dingo_tests

```
* Update package version; remove old CHANGELOG for dingo_tests
* Cleanup package.xml; list dependencies in alphabetical order; remove unused dependencies
* Merge branch 'wip-wheel-joints' into 'noetic-devel'
  Output linear displacement from wheel joints for driveTest()
  See merge request research/cpr_platform_tests!1
* Output linear displacement from wheel joints for driveTest()
* Apply adcTest() changes from previous commit to dingo_tests, husky_tests, jackal_tests, and warthog_tests
* Relocate individual CPR platform test packages to central repository
* Contributors: Joey Yang
```

## husky_tests

```
* Update package version; remove old CHANGELOG for dingo_tests
* Cleanup package.xml; list dependencies in alphabetical order; remove unused dependencies
* Merge branch 'wip-wheel-joints' into 'noetic-devel'
  Output linear displacement from wheel joints for driveTest()
  See merge request research/cpr_platform_tests!1
* Output linear displacement from wheel joints for driveTest()
* Apply adcTest() changes from previous commit to dingo_tests, husky_tests, jackal_tests, and warthog_tests
* Relocate individual CPR platform test packages to central repository
* Contributors: Joey Yang
```

## jackal_tests

```
* Update package version; remove old CHANGELOG for dingo_tests
* Cleanup package.xml; list dependencies in alphabetical order; remove unused dependencies
* Merge branch 'wip-wheel-joints' into 'noetic-devel'
  Output linear displacement from wheel joints for driveTest()
  See merge request research/cpr_platform_tests!1
* Output linear displacement from wheel joints for driveTest()
* Apply adcTest() changes from previous commit to dingo_tests, husky_tests, jackal_tests, and warthog_tests
* Relocate individual CPR platform test packages to central repository
* Contributors: Joey Yang
```

## ridgeback_tests

```
* Update package version; remove old CHANGELOG for dingo_tests
* Cleanup package.xml; list dependencies in alphabetical order; remove unused dependencies
* Merge branch 'wip-wheel-joints' into 'noetic-devel'
  Output linear displacement from wheel joints for driveTest()
  See merge request research/cpr_platform_tests!1
* Output linear displacement from wheel joints for driveTest()
* Separate getAdcTestResults() into getVoltageTestResults() and getCurrentTestResults(); implement getVoltageTestResults() based on percentage thresholds; implement getCurrentTestResults() based on preset 0 to 5 amp range
* Relocate individual CPR platform test packages to central repository
* Contributors: Joey Yang
```

## warthog_tests

```
* Update package version; remove old CHANGELOG for dingo_tests
* Cleanup package.xml; list dependencies in alphabetical order; remove unused dependencies
* Merge branch 'wip-wheel-joints' into 'noetic-devel'
  Output linear displacement from wheel joints for driveTest()
  See merge request research/cpr_platform_tests!1
* Output linear displacement from wheel joints for driveTest()
* Apply adcTest() changes from previous commit to dingo_tests, husky_tests, jackal_tests, and warthog_tests
* Relocate individual CPR platform test packages to central repository
* Contributors: Joey Yang
```
