### PR TITLE
husky_robot: 0.6.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -486,7 +486,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.6.5-1`:

- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.4-1`

## husky_base

- No changes

## husky_bringup

```
* Added Blackfly entry to install script
* Added Blackfly launch file
* Added spinnaker_camera_driver to package.xml
* Add HUSKY_REALSENSE_TOPIC envar for choosing prefix namespace for all realsense topics
* Update realsense launch file based on changes from realsense2_camera
* Contributors: Joey Yang, Luis Camero
```

## husky_robot

- No changes
