### PR TITLE
husky_robot: 0.6.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -486,7 +486,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.6.6-1`:

- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.5-1`

## husky_base

- No changes

## husky_bringup

- No changes

## husky_robot

```
* WIP - Add dependency for husky_tests
* Contributors: Joey Yang
```
