### PR TITLE
dingo: 0.1.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -165,7 +165,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.10-1
+      version: 0.1.11-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.11-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.10-1`

## dingo_control

```
* Enable subst_value in dingo_config_extras
  This should get cherry-picked into Noetic too.
* Contributors: Chris I-B
```

## dingo_description

```
* Added Velodyne HDL32E and Microstrain GX5
* Updated URDF to disable mount
* Update VLP16 with disable tower and set angle on mount
* Add Velodyne HDL32e URDF and meshes
* Contributors: Luis Camero
```

## dingo_msgs

- No changes

## dingo_navigation

- No changes
