### PR TITLE
dingo_robot: 0.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -223,7 +223,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.1.6-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.5-1`

## dingo_base

- No changes

## dingo_bringup

```
* Fix realsense double namespace error
* Update realsense launch file based on changes from realsense2_camera
* Remove unused rs_model argument
* Switch usage of ifconfig (net-tools) to ip (iproute2) (#12 <https://github.com/dingo-cpr/dingo_robot/issues/12>)
  * Switch usage of ifconfig (net-tools) to ip (iproute2)
  * Remove unnecessary "sudo"
* Contributors: Joey Yang
```

## dingo_robot

- No changes
