### PR TITLE
dingo_robot: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -388,7 +388,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.2.2-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-1`

## dingo_base

- No changes

## dingo_bringup

```
* Fix realsense double namespace error
* Updated Bringup (#14 <https://github.com/dingo-cpr/dingo_robot/issues/14>)
  * Added Velodyne HDL32E and Microstrain GX5
  * Added ros_mscl as run_depend in package.xml
  * Alphabetically sort package.xml
* Update realsense launch file based on changes from realsense2_camera
* Remove unused rs_model argument
* Contributors: Joey Yang, luis-camero
```

## dingo_robot

- No changes
