### PR TITLE
husky: 1.0.5-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -26,7 +26,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 1.0.5-1
+      version: 1.0.5-2
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `1.0.5-2`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-1`

## husky_base

```
* Split teleop launch into two files since simulation doesn't need actual joystick and will spam warmings.
* [husky_base] Fixed spawner.py bug.
* [husky_base] Added missing includes for base_launch.py.
* Revamped tele-op launch.
* Fix chnaged dependency in rolling.
* Contributors: Denis Štogl, Tony Baltovski
```

## husky_bringup

```
* Updated package versions for un-released packages.
* [husky_bringup] Disabled gps bringup for now since nmea_navsat_driver isn't released.
* Initial accessories launch file.
* Contributors: Tony Baltovski
```

## husky_control

```
* [husky_control] Fixed deprecated warnings and minor clean up.
* Split teleop launch into two files since simulation doesn't need actual joystick and will spam warmings.
* [husky_control] Removed dupilcate config.
* [husky_control] Added IMU filter.
* Revamped tele-op launch.
* [husky_control] Cleaned up control_launch.py.
* [husky_control] Re-added interactive_marker_twist_server and sorted depends in-order.
* Contributors: Tony Baltovski
```

## husky_description

```
* Switched to gazebo_plugins for IMU and GPS.
* [husky_description] Fixed malformed stl.
* Initial accessories launch file.
* Contributors: Tony Baltovski
```

## husky_desktop

- No changes

## husky_gazebo

```
* Switched to gazebo_plugins for IMU and GPS.
* [husky_gazebo] Removed ros2_control_node from gazebo launch.
* Split teleop launch into two files since simulation doesn't need actual joystick and will spam warmings.
* Revamped tele-op launch.
* Contributors: Tony Baltovski
```

## husky_msgs

- No changes

## husky_robot

```
* Uncomment dependency on husky_bringup
  In light of husky_bringup being completed and released, it makes sense to re-enable this dependency.
* Contributors: Joey Yang
```

## husky_simulator

- No changes

## husky_viz

```
* Revamped tele-op launch.
* Contributors: Tony Baltovski
```
