### PR TITLE
ridgeback_robot: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -797,7 +797,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.3.2-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-1`

## ridgeback_base

- No changes

## ridgeback_bringup

```
* Change the can-udp-bringup to use ip instead of ifconfig (#35 <https://github.com/ridgeback/ridgeback_robot/issues/35>)
  * Change the can-udp-bringup to use ip instead of ifconfig
  * Fix the txqueue length
  * For consistency stick with "link set can0" and not "link set dev can0"
* Contributors: Chris I-B
```

## ridgeback_robot

- No changes
