### PR TITLE
ridgeback_robot: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -713,7 +713,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.4.2-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.1-1`

## ridgeback_base

- No changes

## ridgeback_bringup

- No changes

## ridgeback_robot

```
* Add dependency for ridgeback_tests (#36 <https://github.com/ridgeback/ridgeback_robot/issues/36>)
  This PR should only be merged once the test package is released.
* Contributors: Joey Yang
```
