### PR TITLE
husky: 1.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -26,7 +26,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 1.0.5-2
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `1.0.6-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-2`

## husky_base

```
* Added searching for left and right joints rather than assuming order.
* Contributors: Tony Baltovski
```

## husky_bringup

- No changes

## husky_control

```
* Added searching for left and right joints rather than assuming order.
* Contributors: Tony Baltovski
```

## husky_description

- No changes

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
