### PR TITLE
cpr_platform_tests: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -309,7 +309,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/cpr_platform_tests-gbp.git
-      version: 0.3.0-1
+      version: 0.3.1-1
   cpr_robot_customizer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_platform_tests` to `0.3.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/cpr_platform_tests.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/cpr_platform_tests-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.0-1`

## dingo_tests

```
* Update safety clearance requirements for rotate and drive tests to be consistent with VKS.
* Wipe README file, and add link to tutorial documentation.
* Contributors: Joey Yang
```

## husky_tests

```
* Update safety clearance requirements for rotate and drive tests to be consistent with VKS.
* Wipe README file, and add link to tutorial documentation.
* Load rotateTest() on condition that an external IMU device is detected for husky_tests
* Contributors: Joey Yang
```

## jackal_tests

```
* Update safety clearance requirements for rotate and drive tests to be consistent with VKS.
* Wipe README file, and add link to tutorial documentation.
* Contributors: Joey Yang
```

## ridgeback_tests

```
* Update safety clearance requirements for rotate and drive tests to be consistent with VKS.
* Wipe README file, and add link to tutorial documentation.
* Contributors: Joey Yang
```

## warthog_tests

```
* Update safety clearance requirements for rotate and drive tests to be consistent with VKS.
* Wipe README file, and add link to tutorial documentation.
* Tune rotateTest() and driveTest() params for warthog_tests; increase forward drive distance to 2 metres for warthog_tests
* Contributors: Joey Yang
```
