### PR TITLE
cpr_platform_tests: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -301,6 +301,7 @@ repositories:
   cpr_platform_tests:
     release:
       packages:
+      - boxer_tests
       - dingo_tests
       - husky_tests
       - jackal_tests
@@ -309,7 +310,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/cpr_platform_tests-gbp.git
-      version: 0.3.1-1
+      version: 0.3.2-1
   cpr_robot_customizer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_platform_tests` to `0.3.2-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/cpr_platform_tests.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/cpr_platform_tests-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-1`

## boxer_tests

```
* [boxer_tests] Updated package.xml to match the rest of the packages.
* Add missing package.xml dependencies to boxer_tests
* [boxer_tests] Removed CATKIN_IGNORE.
* Contributors: Joey Yang, Tony Baltovski
```

## dingo_tests

```
* Changes.
* Contributors: Tony Baltovski
```

## husky_tests

```
* Changes.
* Contributors: Tony Baltovski
```

## jackal_tests

```
* Changes.
* Contributors: Tony Baltovski
```

## ridgeback_tests

```
* Changes.
* Contributors: Tony Baltovski
```

## warthog_tests

```
* Changes.
* Contributors: Tony Baltovski
```
