### PR TITLE
cpr_indoornav_husky: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -247,7 +247,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_husky` to `0.3.1-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-husky.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.0-1`

## cpr_indoornav_husky

```
* Change the ROS1->2 bridge domain to 91.
* Fix a bug with the BRIDGE_SETUP_PATH envar
* Update the Husky graphics
* Contributors: Chris Iverach-Brereton
```
