### PR TITLE
cpr_indoornav_jackal: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -262,7 +262,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_jackal-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_jackal` to `0.3.1-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-jackal.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.0-1`

## cpr_indoornav_jackal

```
* Change the ROS1->2 bridge domain to 91
* Fix a bug with the BRIDGE_SETUP_PATH envar
* Contributors: Chris Iverach-Brereton
```
