### PR TITLE
husky: 0.6.4-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -468,7 +468,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.6.3-1
+      version: 0.6.4-2
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.6.4-2`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.6.3-1`

## husky_control

- No changes

## husky_description

```
* Fixes for velodyne prefix
* PACS Brackets (#238 <https://github.com/husky/husky/issues/238>)
  * Added STL models for brackets
  * Added brackets to URDF
  * Added bracket environment variables
* Fixed issues with find
* Added README with all Environment Variables
* Duplicate URDF for every standard sensor
* Added fath pivot mount as dependency
* Added URDF of Blackfly on top of fath_pivot_mount
* Added prefix to name parameter to differentiate between primary and secondary
* Changed ENABLE to ENABLED
* Changed HUSKY_FULL_RISER to HUSKY_FULL_RISER_LEVEL
* Added PACS top plate and mounts to decorations
* Added PACS urdf definitions
* Added PACS meshes
* Contributors: Luis Camero, luis-camero
```

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
