### PR TITLE
husky_robot: 0.6.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -487,7 +487,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.6.6-1
+      version: 0.6.7-1
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.6.7-1`:

- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.6.6-1`

## husky_base

- No changes

## husky_bringup

```
* Fixes for velodyne prefix
* Secondary sensors (#24 <https://github.com/husky/husky_robot/issues/24>)
  * Added second blackfly to launch
  * Fixed prefix in UST10 launch
  * Added remap to launch file to get desired topics
  * Launch file now launches 2 Reaslenses directly using Nodelet launch
  * Added second 3D laser to launch file
  * Added entries for secondary sensors
  * Added new line at EOF
* Use configurable laser prefix
  husky_description supports changing the frame ID, but without being able to change the frame ID in the launch file you wind up with a broken tf
  - https://github.com/husky/husky/blob/2c46d3b0d4815bdf4a8973d62439657155f831da/husky_description/urdf/husky.urdf.xacro#L35
  - https://github.com/husky/husky/blob/2c46d3b0d4815bdf4a8973d62439657155f831da/husky_description/urdf/husky.urdf.xacro#L42
  Also, the existing default "base_laser" is inconsistent with the latest husky_description.
  IndoorNav, because of how Otto's implemented parts of it, currently requires the front & rear lidar frames to be front_laser and rear_laser respectively, so fixing this will also make IndoorNav easier to develop/maintain.
* Contributors: Chris I-B, Luis Camero, luis-camero
```

## husky_robot

- No changes
