### PR TITLE
boxer_robot: 0.1.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -79,7 +79,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/boxer_robot-release.git
-      version: 0.1.6-1
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/boxer-cpr/boxer_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer_robot` to `0.1.7-1`:

- upstream repository: https://github.com/boxer-cpr/boxer_robot.git
- release repository: https://github.com/clearpath-gbp/boxer_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.6-1`

## boxer_base

```
* Update the platform and autonomy bridge domains
* Enable the autonomy bridge, add the autonomy topics to the config file
* Contributors: Chris Iverach-Brereton
```

## boxer_bringup

```
* Start ros-bridge service after the base platform computer comes up and is pingable; otherwise, the ros-bridge service dies upon booting the backpack computer.
* Contributors: Joey Yang
```

## boxer_robot

```
* WIP - Add dependency for boxer_tests
  This PR should only be merged once the test package is released.
* Contributors: Joey Yang
```
