### PR TITLE
video_recorder: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -794,6 +794,24 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/um7-release.git
       version: 0.0.6-1
+  video_recorder:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/video_recorder.git
+      version: noetic-devel
+    release:
+      packages:
+      - video_recorder
+      - video_recorder_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/video_recorder-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/video_recorder.git
+      version: noetic-devel
+    status: developed
   warthog:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_recorder` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/video_recorder.git
- release repository: https://github.com/clearpath-gbp/video_recorder-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## video_recorder

```
* Initial release
* Contributors: Chris Iverach-Brereton
```

## video_recorder_msgs

```
* Initial release
* Contributors: Chris Iverach-Brereton
```
