### PR TITLE
dingo_firmware_components: 2.9.13-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -375,7 +375,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware_components.git
-      version: 2.9.13-1
+      version: 2.9.13-2
   dingo_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_firmware_components` to `2.9.13-2`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_firmware_components.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware_components.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.9.13-1`

## dingo_firmware_components

```
* Removed exec depend on python-tftpy since it is not installable on Focal.
* Contributors: Tony Baltovski
```
