### PR TITLE
cpr_gps_common: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -169,6 +169,7 @@ repositories:
       - cpr_geodetic_survey
       - cpr_gps_common
       - cpr_gps_navigation_msgs
+      - cpr_outdoornav_support
       - cpr_pointcloud_filter
       - cpr_robot_indicators
       - cpr_std_srvs
@@ -178,7 +179,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
-      version: 0.2.0-3
+      version: 0.2.1-1
     status: maintained
   cpr_gps_navigation:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_common` to `0.2.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/cpr-outdoornav/cpr_gps_common.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_common-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-3`

## autonomy_msgs

- No changes

## autonomy_msgs_utils

- No changes

## cpr_autonomy_metrics

- No changes

## cpr_diagnostics

- No changes

## cpr_estop_monitor

- No changes

## cpr_geodetic_survey

- No changes

## cpr_gps_common

- No changes

## cpr_gps_navigation_msgs

- No changes

## cpr_outdoornav_support

```
* added support script to collect data from customer's robot PC related to OutdoorNav
* Contributors: David, Teresi, José Mastrangelo
```

## cpr_pointcloud_filter

- No changes

## cpr_robot_indicators

- No changes

## cpr_std_srvs

- No changes

## mission_msgs

- No changes

## nav_core_cpr

- No changes

## nav_utils

- No changes
