### PR TITLE
cpr_gps_tasks: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -207,7 +207,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     status: maintained
   cpr_indoornav_base:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_tasks` to `0.2.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/cpr-outdoornav/cpr_gps_tasks.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/cpr_gps_tasks-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## cpr_gps_camera_tasks

- No changes

## cpr_gps_generic_tasks

- No changes

## cpr_gps_tasks

- No changes
