### PR TITLE
cpr_gps_navigation: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -196,7 +196,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     status: maintained
   cpr_gps_tasks:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gps_navigation` to `0.2.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/cpr-outdoornav/cpr_gps_navigation.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/cpr_gps_navigation-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## cpr_gps_costmap_layers

- No changes

## cpr_gps_localization

```
* EKF node names have changed
* Contributors: José Mastrangelo
```

## cpr_gps_navigation

- No changes

## cpr_gps_navigation_client

- No changes

## cpr_gps_navigation_server

```
* Predocking will now use Dubins
* changed parameter name to match changes in gps_mpc_navigation
* Update goal tolerance parameters based on testing results
* Remove deprecated function to call tasks as services
* traking service renamed and changed to std_srvs/Trigger
* Contributors: José Mastrangelo
```

## cpr_gps_path_smoothing

```
* Renamed path smoothing action
* Contributors: José Mastrangelo
```

## cpr_gps_safety

- No changes

## cpr_lidar_odometry

```
* changes to match new EKF node names
* Contributors: José Mastrangelo
```

## cpr_sbpl_lattice_planner

- No changes
