### PR TITLE
cpr_gazebo: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -152,7 +152,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_gazebo-release.git
-      version: 0.2.1-2
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gazebo` to `0.2.2-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_gazebo.git
- release repository: https://github.com/clearpath-gbp/cpr_gazebo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.2.1-2`

## cpr_agriculture_gazebo

- No changes

## cpr_inspection_gazebo

```
* Add the water mesh to the visualization since UUV is disabled. This way the water at least renders, even if it doesn't have any physics
* Contributors: Chris Iverach-Brereton
```

## cpr_obstacle_gazebo

- No changes

## cpr_office_gazebo

- No changes

## cpr_orchard_gazebo

```
* Add the install directive to the orchard world
* Contributors: Chris Iverach-Brereton
```

## gazebo_race_modules

- No changes
