### PR TITLE
axis_camera: 0.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -22,7 +22,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/axis_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.4.3-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.2-1`

## axis_camera

```
* Merge pull request #73 <https://github.com/ros-drivers/axis_camera/issues/73> from jhiggins-cpr/noetic-devel
  Add frames-per-second (fps) as a configurable option
* Reverting package change as it happens automatically
* Add frames-per-second (fps) as a configurable option
* Contributors: Jason Higgins, Tony Baltovski
```
