### PR TITLE
video_recorder: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -802,12 +802,14 @@ repositories:
       version: noetic-devel
     release:
       packages:
+      - audio_recorder
+      - audio_recorder_msgs
       - video_recorder
       - video_recorder_msgs
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/video_recorder-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/video_recorder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_recorder` to `0.0.3-1`:

- upstream repository: https://github.com/clearpathrobotics/video_recorder.git
- release repository: https://github.com/clearpath-gbp/video_recorder-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## audio_recorder

```
* Update the docs, add the is_recording + default filename to the audio recorder
* Add the first-pass audio-recorder action server. Very similar format to the video recorder, but for dumping ALSA input to wav files.
* Contributors: Chris Iverach-Brereton
```

## audio_recorder_msgs

```
* Add the first-pass audio-recorder action server. Very similar format to the video recorder, but for dumping ALSA input to wav files
* Contributors: Chris Iverach-Brereton
```

## video_recorder

```
* Allow cancelling fixed-duration videos
* Create the output directory if it doesn't already exist
* Contributors: Chris Iverach-Brereton
```

## video_recorder_msgs

- No changes
