### PR TITLE
boxer: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -42,7 +42,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/boxer-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/boxer-cpr/boxer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boxer` to `0.1.2-1`:

- upstream repository: https://github.com/boxer-cpr/boxer.git
- release repository: https://github.com/clearpath-gbp/boxer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## boxer_control

```
* Merge pull request #1 <https://github.com/boxer-cpr/boxer/issues/1> from boxer-cpr/missing-depends
  Add missing dependencies to package.xml
* Add missing exec_depends. Should resolve the warnings with releasing cpr_gazebo
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## boxer_description

```
* Merge pull request #2 <https://github.com/boxer-cpr/boxer/issues/2> from boxer-cpr/jyang-patch
* Update README
* Add BOXER_PC_XYZ and BOXER_PC_RPY envars to support relocating backpack computer in URDF
* Add ECX-2000 URDF for backpack computer; removed unsupported ECX-1000
* Contributors: Chris Iverach-Brereton, Joey Yang
```

## boxer_msgs

- No changes

## boxer_navigation

- No changes
