### PR TITLE
jackal_desktop: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -58,6 +58,24 @@ repositories:
       url: https://github.com/jackal/jackal.git
       version: foxy-devel
     status: developed
+  jackal_desktop:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: foxy-devel
+    release:
+      packages:
+      - jackal_desktop
+      - jackal_viz
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_desktop-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: foxy-devel
+    status: maintained
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_desktop` to `1.0.1-1`:

- upstream repository: https://github.com/jackal/jackal_desktop.git
- release repository: https://github.com/clearpath-gbp/jackal_desktop-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## jackal_desktop

- No changes

## jackal_viz

```
* [jackal_viz] Changes rviz to rviz2.
* Contributors: Tony Baltovski
```
