### PR TITLE
jackal_simulator: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -76,6 +76,24 @@ repositories:
       url: https://github.com/jackal/jackal_desktop.git
       version: foxy-devel
     status: maintained
+  jackal_simulator:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_simulator.git
+      version: foxy-devel
+    release:
+      packages:
+      - jackal_gazebo
+      - jackal_simulator
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_simulator-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_simulator.git
+      version: foxy-devel
+    status: developed
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_simulator` to `1.0.0-1`:

- upstream repository: https://github.com/jackal/jackal_simulator
- release repository: https://github.com/clearpath-gbp/jackal_simulator-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## jackal_gazebo

```
* Cleanup
* Working gazebo
* Contributors: Roni Kreinin
```

## jackal_simulator

```
* Working gazebo
* Contributors: Roni Kreinin
```
