### PR TITLE
wireless: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -109,5 +109,23 @@ repositories:
       url: https://github.com/ros2/teleop_twist_joy.git
       version: foxy
     status: maintained
+  wireless:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: foxy-devel
+    release:
+      packages:
+      - wireless_msgs
+      - wireless_watcher
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/wireless-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: foxy-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## wireless_msgs

```
* Minor fixes
* Updated wireless_msgs for ROS2.
  Updated wireless_watcher for ROS2.
* Contributors: Roni Kreinin
```

## wireless_watcher

```
* Minor fixes
* Added previous changelogs
* Updated wireless_msgs for ROS2.
  Updated wireless_watcher for ROS2.
* Contributors: Roni Kreinin
```
