### PR TITLE
jackal_robot: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -76,6 +76,21 @@ repositories:
       url: https://github.com/jackal/jackal_desktop.git
       version: foxy-devel
     status: maintained
+  jackal_robot:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_robot-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_robot.git
+      version: foxy-devel
+    status: maintained
   jackal_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `1.0.0-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## jackal_robot

```
* Fixed copyright
  Added diagnostic dependencies
* Ignore __pycache__
* Added jackal_diagnostics
* Added install and uninstall scripts for robot_upstart job
  Launch file cleanup
* Added exec dependencies
* Added accessories launch
* Minor hardware fix
* Consolidated jackal_base and jackal_bringup into one package 'jackal_robot'
* Velocity mode when 0 velocity is commanded
* Renamed JackalBase to JackalHardwareInterface
  Reverted package version and description to current values
  Use /dev/jackal as the micro ros serial device
* Removed unused variables.
  Updated copyright.
* rclcpp::spin_some before checking for feedback
* Mutex on feedback message
* Working ros2_control
* Add dependency for jackal_tests (#54 <https://github.com/jackal/jackal_robot/issues/54>)
  This PR should only be merged once the test package is released.
* Add Blackfly to accessories launch
* Added spinnaker_camera_driver to package.xml
* Contributors: Joey Yang, Luis Camero, Roni Kreinin
```
