### PR TITLE
jackal_robot: 0.7.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -561,7 +561,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.7.4-1
+      version: 0.7.5-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.7.5-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.4-1`

## jackal_base

```
* use quiet_NaN for C++03 compatibility
* Changed method JackalHardware::copyJointsFromHardware() so that the robot
  odomety resets to zero upon restart of the node.
  Previously, old state information would be retained, leading to
  incorrect localization behavior.
* Change sensor_msgs/MagneticField member to magnetic_field from vector
* Contributors: Blake Anderson, Stijn Eijndhoven
```

## jackal_bringup

```
* Replace ros_mscl with microstrain_inertial_driver
* Add Blackfly to accessories launch
* Added spinnaker_camera_driver to package.xml
* Contributors: Joey Yang, Luis Camero
```

## jackal_robot

```
* Add dependency for jackal_tests (#54 <https://github.com/jackal/jackal_robot/issues/54>)
  This PR should only be merged once the test package is released.
* Contributors: Joey Yang
```
