### PR TITLE
dingo: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -341,7 +341,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.10-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.2.0-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.10-1`

## dingo_control

- No changes

## dingo_description

```
* Customizable PACS riser heights
* Added Flir Blackfly
* Updated Realsense comments and include parameter
* Fixed typo in material name
* Added secondary realsense
* Added README with all URDF environment variables
* Force upper case for environment variables (#21 <https://github.com/dingo-cpr/dingo/issues/21>)
  * Added PACS
  * Changed enable envvar name
  * Added EOL
  * All caps for envvars
* Added PACS (#20 <https://github.com/dingo-cpr/dingo/issues/20>)
  * Added PACS
  * Changed enable envvar name
  * Added EOL
* Contributors: Luis Camero, luis-camero
```

## dingo_msgs

- No changes

## dingo_navigation

- No changes
