### PR TITLE
yperio: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -931,7 +931,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/yperio-gbp.git
-      version: 0.1.5-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/yperio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yperio` to `0.2.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/yperio.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/yperio-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.5-1`

## yperio

```
* Removed markdown
* Fixed Blackfly variable names
* Added edit options to summary
* Fixed bracket capitalization
* Load and Save brackets from YAML
* Added Dingo microstrain
* Updated Dingo summary
* Add generic summary prints
* Fixed IP and Topic not being set
* Fixed bug where config would not switch to summary prompt
* Added Dingo prompts
* Updated yperio_cli to use states
* Images for markdown tutorials
* Prompting utilities
* Added Zed2 camera
* Added checks for float values
* Added hardpoints
* Renamed realsense parameters
* Renamed Blacfkly files
* Keep type as all caps
* Changed yaml flow style to None to prevent formatting
* Updated prompts
* Updated tags and names of secondary payloads
* Nested auto-completer
* Added access by type to payload manager
* Add PACS parameter functions
* State prompts
* Fixed strict lenght requirements for list parameters
* Added preliminary jackal payloads
* Fixed only save selected payloads to yaml
* Added hardcoded mounting location visual
* Added PACS hardpoint visual (grid visualization)
* Fixed status print and added PACS grid
* Fixed indentation when printing parameters
* Fixed status code of successful YAML and BASH save methods
* Add name to paramater manager
* Renamed parameters to remove unecessary prefixes
* Removed previous module scripts from setup
* Added Husky standard payloads
* Updated status updates and included PACS mounts
* Added status and description
* Added payload status and PACS hardpoints
* Updated load function names
* Sort payloads by name and type
* Updates mounting locations for autocompletion
* Added methods required to make a BaseRobot act like BasePayload in printing parameters
* Added status and description to clarify further steps
* Added preset choices to EVParent to allow for autocomplete mounting locations
* Removed old module directory structure
* Updated jackal to load name of robot into managers
* Updated CLI to match new Yperio Module
* Removed setting value from config status update
* Fixed bug where empty path would resolve in file named None
* Added parent (payload or robot) name to parameter status updates
* Removed old method to save robot setup bash
* Added obtaining robot setup bash lines
* Added saving robot setup bash
* Removed saving robot setup bash
* Updated envvar export lines
* Moved YAML parsing functions to utils
* Removed deprecated functions
* Changed command name from 'edit' to 'set'
* Added loading configuration methods
* Added loading and saving YAML configurations
* Updated config loading
* Added config member variable, loading configs, and names now display in Status messages
* Updated load function
* Added Parameter and Payload Managers
* Updated to use ParameterManager
* Split set with set and set from string
* Added placeholder files
* Added dummy parameters
* Added clear method
* Added find and get member functions
* Added set, get, and is_param checks
* Added Status and Description member variables to BasePayload
* Added basic methods to BaseRobot class
* Added dependants and children parameters
* Added new structure to setup.py
* Added new structure to python module
* Update README.md
* Update README.md
* Contributors: Luis Camero
```
