### PR TITLE
dingo_robot: 0.2.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -390,7 +390,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.2.4-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-1`

## dingo_base

- No changes

## dingo_bringup

```
* Fixed point_cloud parameter
* Contributors: Luis Camero
```

## dingo_robot

- No changes
