### PR TITLE
cpr_indoornav_jackal: 0.3.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -263,7 +263,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_jackal-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_jackal` to `0.3.4-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-jackal.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.3-1`

## cpr_indoornav_jackal

```
* Use a 30-sample rolling average for the battery percentage instead of single samples. On Jackal this equates to ~30s averages
* Add a group for wireless charge docking if applicable
* Reduce the upper limit for the full battery voltage to 28.8V. See OPG02-76
* Contributors: Chris Iverach-Brereton
```
