### PR TITLE
cpr_indoornav_husky: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -248,7 +248,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_husky` to `0.3.3-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-husky.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.2-1`

## cpr_indoornav_husky

```
* Add a block for wireless charge docking if necessary
* Add the web GUI input
* Add the option to override the ROS2 bridge topics
* Contributors: Chris Iverach-Brereton
```
