### PR TITLE
cpr_indoornav_base: 0.3.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -218,7 +218,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_base-release.git
-      version: 0.3.3-2
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr_indoornav_base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_base` to `0.3.4-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-base.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_base-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.3-2`

## cpr_indoornav_base

```
* Update docking controller file
* Add wireless docking support
* Assume always 2 lasers in indoornav
* Fix value to default in launch
* Moved controller launch to each repo since envvars relative to each robot
* Added lanuch files for running indoornav docking
* Add instructions for building the ROS2 SDK examples since they require manual fixes
* Contributors: Chris Iverach-Brereton, José Mastrangelo
```
