### PR TITLE
husky: 0.6.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -469,7 +469,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.6.4-4
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.6.5-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.4-4`

## husky_control

```
* Fixed all scan topics to use front/scan.
* Disable keyboard input by default; on a normal robot this is launched by the systemd job, where there will never be any keyboard input.
* Separate the keyboard teleop to a separate topic, add the new topic to the twist_mux
* Move the keyboard teleop launch into the main teleop file, add an arg to optionally disable it
* Update package.xml
* Update CHANGELOG.rst
* Update CMakeLists.txt
* Update package.xml
* Update CHANGELOG.rst
* Update teleop_keyboard.launch
* Update CMakeLists.txt
* Remove scripts
* Update CHANGELOG.rst
* Update teleop_keyboard.launch
* Create teleop_keyboard.launch
* Update CMakeLists.txt
* Update CMakeLists.txt
* Update CMakeLists.txt
* Update package.xml
* Update package.xml
* Update package.xml
* Update package.xml
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Update teleop_keyboard.py
* Create teleop_keyboard.py
* Update LICENSE
* Create LICENSE
* Contributors: Chris Iverach-Brereton, Tinker Twins, Tony Baltovski
```

## husky_description

```
* Removed old bracket
* Updated brackets
* Change the reference heading of the GPS plugin to be east so the coordinate system is ENU
* Rename DATUM_* to GAZEBO_WORLD_*. We're separating the datum from the world's origin, and this keeps envars from clobbering each other
* LMS1XX Tower EnvVar (#250 <https://github.com/husky/husky/issues/250>)
  * Added second velodyne description
  * Added environment variable to remove the LMS1XX mount
  * Removed console output
* Use DATUM_LAT and DATUM_LON envars to override the default reference lat/lon for the Gazebo GPS plugin. This addresses a compatibility issue with outdoor nav simulations
* Contributors: Chris Iverach-Brereton, Luis Camero, luis-camero
```

## husky_desktop

- No changes

## husky_gazebo

```
* Add XML decleration to realsense.launch
* Update realsense.launch
* Update realsense.launch
* Contributors: Tinker Twins
```

## husky_msgs

- No changes

## husky_navigation

```
* Fixed all scan topics to use front/scan.
* [husky_navigation] Updated DWAPlannerROS to use non-deprecated parameters.
* Contributors: Tony Baltovski
```

## husky_simulator

- No changes

## husky_viz

```
* Fixed all scan topics to use front/scan.
* Contributors: Tony Baltovski
```
