### PR TITLE
husky: 0.4.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -437,7 +437,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.4.12-1
+      version: 0.4.13-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.4.13-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.12-1`

## husky_base

- No changes

## husky_bringup

```
* Add HUSKY_REALSENSE_TOPIC envar for choosing prefix namespace for all realsense topics
* Update realsense launch file based on changes from realsense2_camera
* Contributors: Joey Yang
```

## husky_control

```
* Fixed all scan topics to use front/scan.
* Remove whitespace
* Merge pull request #217 <https://github.com/husky/husky/issues/217> from husky/jyang-cpr-patch-1
  Update DiffDriveController params
* Contributors: Joey Yang, Tony Baltovski
```

## husky_description

```
* Added Wibotic mesh and STL
* Contributors: Luis Camero
```

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

```
* Fixed all scan topics to use front/scan.
* Contributors: Tony Baltovski
```

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

```
* Fixed all scan topics to use front/scan.
* Contributors: Tony Baltovski
```
