### PR TITLE
cpr_gazebo: 0.2.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -143,6 +143,7 @@ repositories:
       version: noetic-devel
     release:
       packages:
+      - cpr_accessories_gazebo
       - cpr_agriculture_gazebo
       - cpr_inspection_gazebo
       - cpr_obstacle_gazebo
@@ -152,7 +153,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_gazebo-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gazebo` to `0.2.4-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_gazebo.git
- release repository: https://github.com/clearpath-gbp/cpr_gazebo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-1`

## cpr_accessories_gazebo

```
* Add a new accessories package with the charge dock and base station. Add view_world.launch files to all relevant packages so you can view the environment without spinning up Gazebo. Add the wireless charge dock and base station to the agriculture world
* Contributors: Chris Iverach-Brereton
```

## cpr_agriculture_gazebo

```
* Move the wireless charge dock back outside
* Fix the world geometry to use ENU, fix the sun direction so it makes sense for the world
* Update the datum scripts to use the new envars
* Rotate the world so that north is along the X axis
* Add the top-down tif images for generating map tiles of the world. Add a script that can be sourced to set the datum
* Rotate the world so it aligns with ENU
* Add a new accessories package with the charge dock and base station. Add view_world.launch files to all relevant packages so you can view the environment without spinning up Gazebo. Add the wireless charge dock and base station to the agriculture world
* Contributors: Administrator, Chris Iverach-Brereton
```

## cpr_inspection_gazebo

```
* Adjust the orchard and inspection worlds to use ENU coordinates for the world frame. Fix the robot spawn points, GPS base-station locations, and default camera orientations accordingly
* Update the datum scripts to use the new envars
* Increase the scale of the water table model to match the world
* Add the base station object on the shore of the lake
* Increase the horizontal scale of the world to make the hill proportionally shallower. Re-tag the geotif with updated coordiantes
* Add geotagged tif of the inspection world, move the origin to be vaguely representative of a lake in northern Alberta
* Add the rviz directory to the install targets
* Add a new accessories package with the charge dock and base station. Add view_world.launch files to all relevant packages so you can view the environment without spinning up Gazebo. Add the wireless charge dock and base station to the agriculture world
* Contributors: Chris Iverach-Brereton
```

## cpr_obstacle_gazebo

```
* Add the rviz directory to the install targets
* Add a new accessories package with the charge dock and base station. Add view_world.launch files to all relevant packages so you can view the environment without spinning up Gazebo. Add the wireless charge dock and base station to the agriculture world
* Contributors: Chris Iverach-Brereton
```

## cpr_office_gazebo

```
* Add the rviz directory to the install targets
* Add a new accessories package with the charge dock and base station. Add view_world.launch files to all relevant packages so you can view the environment without spinning up Gazebo. Add the wireless charge dock and base station to the agriculture world
* Contributors: Chris Iverach-Brereton
```

## cpr_orchard_gazebo

```
* Adjust the orchard and inspection worlds to use ENU coordinates for the world frame. Fix the robot spawn points, GPS base-station locations, and default camera orientations accordingly
* Update the datum scripts to use the new envars
* Move the origin to an orchard in Greece, add the datum script, add top-down tif + geotagged tif images, add the base station model near the origin
* Add axes to the default world view
* Add the rviz directory to the install targets
* Add a new accessories package with the charge dock and base station. Add view_world.launch files to all relevant packages so you can view the environment without spinning up Gazebo. Add the wireless charge dock and base station to the agriculture world
* Contributors: Chris Iverach-Brereton
```

## gazebo_race_modules

- No changes
