### PR TITLE
jackal_robot: 0.7.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -562,7 +562,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_robot-release.git
-      version: 0.7.6-1
+      version: 0.7.7-1
     source:
       type: git
       url: https://github.com/jackal/jackal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_robot` to `0.7.7-1`:

- upstream repository: https://github.com/jackal/jackal_robot.git
- release repository: https://github.com/clearpath-gbp/jackal_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.6-1`

## jackal_base

```
* [jackal_base] Added support for checking for $GNRMC in NMEA sentence and also removed ROS param for which sentence to look for.
* Contributors: Tony Baltovski
```

## jackal_bringup

- No changes

## jackal_robot

- No changes
