### PR TITLE
husky_robot: 0.6.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -489,7 +489,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.6.7-1
+      version: 0.6.8-1
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.6.8-1`:

- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.7-1`

## husky_base

```
* [husky_base] Updated diagnostics for motor and motor driver temperatures.
* Contributors: Tony Baltovski
```

## husky_bringup

```
* Removed manual definition of base_frame_id
* [husky_bringup] Updated compute_calibration to use MagneticField message.
* Fix MagneticField msg reading
* Contributors: Luis Camero, Saurav Agarwal, Tony Baltovski
```

## husky_robot

- No changes
