### PR TITLE
moose_firmware: 0.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -644,7 +644,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/moose_firmware-gbp.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/moose_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_firmware` to `0.1.0-2`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/moose_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/moose_firmware-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## moose_firmware

```
* Updated generator start logic.
* Initial commit
* Contributors: Tony Baltovski
```
