### PR TITLE
simple_term_menu_vendor: 1.5.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -118,7 +118,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/clearpath-gbp/simple_term_menu_vendor-release.git
-      version: 1.5.5-1
+      version: 1.5.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/simple-term-menu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_term_menu_vendor` to `1.5.6-1`:

- upstream repository: https://github.com/clearpathrobotics/simple-term-menu.git
- release repository: https://github.com/clearpath-gbp/simple_term_menu_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.5-1`

## simple_term_menu_vendor

```
* Removed unused files
  Added testing dependencies
* Contributors: Roni Kreinin
```
