### PR TITLE
warthog_robot: 0.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -899,7 +899,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/warthog_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_robot` to `0.2.3-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/warthog_robot.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/warthog_robot-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## warthog_base

```
* [warthog_base] Added Valence BMS.
* Contributors: Tony Baltovski
```

## warthog_bringup

- No changes

## warthog_robot

```
* Merge branch 'warthog_tests' into 'noetic-devel'
  Add dependency for warthog_tests
  See merge request research/warthog_robot!9
* Add dependency for warthog_tests
* Contributors: Joey Yang, Tony Baltovski
```
