### PR TITLE
cpr_gazebo: 0.2.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -153,7 +153,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_gazebo-release.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gazebo` to `0.2.6-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_gazebo.git
- release repository: https://github.com/clearpath-gbp/cpr_gazebo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.5-1`

## cpr_accessories_gazebo

- No changes

## cpr_agriculture_gazebo

```
* Fix the location of the base station in the agriculture world
* Contributors: Chris Iverach-Brereton
```

## cpr_inspection_gazebo

- No changes

## cpr_obstacle_gazebo

- No changes

## cpr_office_gazebo

- No changes

## cpr_orchard_gazebo

- No changes

## gazebo_race_modules

- No changes
