### PR TITLE
cpr_gazebo: 0.2.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -145,6 +145,7 @@ repositories:
       packages:
       - cpr_accessories_gazebo
       - cpr_agriculture_gazebo
+      - cpr_empty_gazebo
       - cpr_inspection_gazebo
       - cpr_obstacle_gazebo
       - cpr_office_gazebo
@@ -153,7 +154,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_gazebo-release.git
-      version: 0.2.6-1
+      version: 0.2.7-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_gazebo` to `0.2.7-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_gazebo.git
- release repository: https://github.com/clearpath-gbp/cpr_gazebo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.6-1`

## cpr_accessories_gazebo

- No changes

## cpr_agriculture_gazebo

```
* Fix a typo in almost every readme, add the new empty world with support for all platforms
* Contributors: Chris Iverach-Brereton
```

## cpr_empty_gazebo

```
* Initial commit of the new empty world
* Contributors: Chris Iverach-Brereton
```

## cpr_inspection_gazebo

```
* Fix a typo in almost every readme, add the new empty world with support for all platforms
* Contributors: Chris Iverach-Brereton
```

## cpr_obstacle_gazebo

- No changes

## cpr_office_gazebo

```
* Fix a typo in almost every readme, add the new empty world with support for all platforms
* Contributors: Chris Iverach-Brereton
```

## cpr_orchard_gazebo

```
* Fix a typo in almost every readme, add the new empty world with support for all platforms
* Contributors: Chris Iverach-Brereton
```

## gazebo_race_modules

- No changes
