### PR TITLE
jackal_firmware: 0.4.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -544,7 +544,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
-      version: 0.4.5-1
+      version: 0.4.6-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/jackal_firmware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_firmware` to `0.4.6-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/jackal_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/jackal_firmware-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.5-1`

## jackal_firmware

```
* Added motor controller enabled for hardware revision 1.
* Made fan enable temperature a static const.
* Added hardware ID checking.
* Added navsat configuration for new GPS module.
* Populated driver_fault from hardware.
* Contributors: Tony Baltovski
```
