### PR TITLE
cpr_indoornav_tests: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -295,7 +295,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_tests-release.git
-      version: 0.3.1-2
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-tests.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_tests` to `0.3.2-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-tests.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_tests-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-2`

## cpr_indoornav_tests

```
* Add tests for EKF since it must be enabled for IndoorNav to operate properly
* Contributors: Chris Iverach-Brereton
```
