### PR TITLE
wibotic-ros-can-connector: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -924,6 +924,24 @@ repositories:
       url: https://github.com/warthog-cpr/warthog_simulator.git
       version: melodic-devel
     status: maintained
+  wibotic-ros-can-connector:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wibotic-ros-can-connector.git
+      version: noetic-devel
+    release:
+      packages:
+      - wibotic_connector_can
+      - wibotic_msg
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/wibotic-ros-can-connector_release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wibotic-ros-can-connector.git
+      version: noetic-devel
+    status: maintained
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wibotic-ros-can-connector` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/wibotic-ros-can-connector.git
- release repository: https://github.com/clearpath-gbp/wibotic-ros-can-connector_release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## wibotic_connector_can

```
* Updated CMakeLists and package.xml
* Updated uavcan dependency
* Added load_peak script and udev rules
* Added charging state publisher
* Update repository to Rev_19
* Update repository to Rev_18
* Update repository to Rev_15
* Adds installation directives to wibotic_connector_can CMakeLists.
* Update repository to Rev_14
* Update repository to Rev_12
* Added sample launch file
* Changed wiboticros.py permissions so it can be roslaunched
* Update repository to Rev_8
* Update repo to Rev_7
* Contributors: Matthew Barulic, Rob Reid, Roni Kreinin, WiBotic Bot, alexfwibotic, wiboticalex
```

## wibotic_msg

```
* Updated CMakeLists and package.xml
* Removes breaking library declaration
* Update repository to Rev_8
* Update repo to Rev_7
* Contributors: Matthew Barulic, Roni Kreinin, WiBotic Bot, wiboticalex
```
