### PR TITLE
wibotic-ros-can-connector: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -936,7 +936,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/wibotic-ros-can-connector_release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/wibotic-ros-can-connector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wibotic-ros-can-connector` to `0.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/wibotic-ros-can-connector.git
- release repository: https://github.com/clearpath-gbp/wibotic-ros-can-connector_release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`

## wibotic_connector_can

```
* Changed data info logs to debug logs
* Contributors: Roni Kreinin
```

## wibotic_msg

- No changes
