### PR TITLE
dingo_robot: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -392,7 +392,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.2.4-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.3.0-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.4-1`

## dingo_base

```
* Updated reset and low battery lighting patterns
* Added D150 battery levels
* Added Wibotic charging status to dingo_lighting
  Renamed PUMA can interface to vcan0
  Added Wibotic launch to accessories.launch
* Fixed pulse pattern to properly pulse between any two colours
* Added shore and charging lighting pattern
  Ignore puma bridge fault when EStopped
  Map lights to motors for puma faults
* Green pulse for charging
* Updated how lighting state is determined
  Improved pulsing logic
* Split Fault into Shore, Puma, and Battery Fault
  Added Pulsing lighting
  Use std lib instead of boost
* Added shore power lighting
* Contributors: Roni Kreinin
```

## dingo_bringup

```
* Added Wibotic charging status to dingo_lighting
  Renamed PUMA can interface to vcan0
  Added Wibotic launch to accessories.launch
* [dingo_bringup] Switched flir_camera_driver to spinnaker_camera_driver as dep.
* Microstrain uses microstrain.yaml instead of deprecated ROS launch arguments
* Contributors: Joey Yang, Roni Kreinin, Tony Baltovski
```

## dingo_robot

- No changes
