### PR TITLE
dingo_firmware: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -368,11 +368,20 @@ repositories:
       version: master
     status: maintained
   dingo_firmware:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware-gbp.git
-      version: 0.3.0-1
+      version: 0.3.1-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git
+      version: noetic-devel
+    status: maintained
   dingo_firmware_components:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_firmware` to `0.3.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/dingo_firmware.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/dingo_firmware-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`

## dingo_firmware

```
* Added low voltage cutoff
* Contributors: Roni Kreinin
```
