### PR TITLE
husky_robot: 0.6.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -499,7 +499,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.6.8-1
+      version: 0.6.9-1
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.6.9-1`:

- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.8-1`

## husky_base

- No changes

## husky_bringup

```
* Updated Secondary Realsense Variables
* Create README.md
* Change HUSKY_IMU_MICROSTRAIN_PORT to HUSKY_IMU_PORT for Microstrain IMU to maintain backwards compatability with legacy microstrain launch file.
* Replace ros_mscl with microstrain_inertial_driver
* Contributors: Joey Yang, luis-camero
```

## husky_robot

- No changes
