### PR TITLE
cpr_onav_description: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -301,6 +301,13 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr-indoornav-tests.git
       version: noetic-devel
     status: developed
+  cpr_onav_description:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_onav_description-release.git
+      version: 0.1.0-1
+    status: maintained
   cpr_platform_tests:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_onav_description` to `0.1.0-1`:

- upstream repository: https://github.com/cpr-application/cpr_onav_description.git
- release repository: https://github.com/clearpath-gbp/cpr_onav_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cpr_onav_description

```
* Added STL files for Starter Kit, Velodynes and Realsense D435s
* Added urdf files for starter and standard kits
* Contributors: José Mastrangelo
```
