### PR TITLE
axis_camera: 0.4.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -22,7 +22,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
-      version: 0.4.3-1
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/ros-drivers/axis_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.4.4-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.3-1`

## axis_camera

```
* Improve support for the F34 multi-camera controller by adding default values for the camera index (1-4). Change the camera arg in view_axis to camera_name, change its default IP address to better-match with the main axis.launch file
* Merge latest changes in master into noetic-devel
* Merge Q62 support into noetic-devel branch (#76 <https://github.com/ros-drivers/axis_camera/issues/76>)
  * Add support for the Q6215 IR mode, defogger, and wiper
  * Ensure that wiper, defog, IR modes are all disabled on startup
  * Add a launch argument to expose the encrypted password option
  * Add support for basic & digest HTTP authorization
  * Rewrite some of the underling CGI calls to use requests to make the code easier to maintain
  * Add support for authentication to the PTZ node
  * Enable password encryption in view_axis.launch
  * Expand the readme with details on usage, supported devices, available topics & services
  * Add python3-requests as a dependendency
  * Add support for the autoiris feature available on some cameras
* Contributors: Chris Iverach-Brereton
```
