### PR TITLE
flir_ptu: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -457,6 +457,25 @@ repositories:
       url: https://github.com/ros-drivers/flir_camera_driver.git
       version: noetic-devel
     status: maintained
+  flir_ptu:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: noetic-devel
+    release:
+      packages:
+      - flir_ptu_description
+      - flir_ptu_driver
+      - flir_ptu_viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/flir_ptu-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: noetic-devel
+    status: maintained
   gps_mpc_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.2.2-1`:

- upstream repository: https://github.com/ros-drivers/flir_ptu.git
- release repository: https://github.com/clearpath-gbp/flir_ptu-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## flir_ptu_description

```
* Merge pull request #50 <https://github.com/ros-drivers/flir_ptu/issues/50> from ros-drivers/wip-simulation
  Add Gazebo Support
* Use a pair of JointPositionControllers to provide gazebo simulation support for the PTU
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## flir_ptu_driver

```
* Linting
* Merge pull request #50 <https://github.com/ros-drivers/flir_ptu/issues/50> from ros-drivers/wip-simulation
  Add Gazebo Support
* Add additional dependencies
* Merge pull request #51 <https://github.com/ros-drivers/flir_ptu/issues/51> from ros-drivers/no-velocity
  Do not include velocity in the published joint_state messages
* Omit the joint_state.velocity array; it was publishing the configured max velocity, not the actual speed of rotation
* Fix some namespace bugs with the PID controllers, fix some copy-paste errors with the pan/tilt angle limits
* Use a pair of JointPositionControllers to provide gazebo simulation support for the PTU
* Merge pull request #48 <https://github.com/ros-drivers/flir_ptu/issues/48> from jyang-cpr/noetic-devel
  Expose connection_type, ip_addr, and tcp_port as launch arguments.
* Merge pull request #47 <https://github.com/ros-drivers/flir_ptu/issues/47> from luis-camero/noetic-devel
  Update disable limits to use read and write
* Merge pull request #46 <https://github.com/ros-drivers/flir_ptu/issues/46> from luis-camero/noetic-devel
  Noetic TCP Flir PTU
* Changed TAB to spaces
* Added TCP to Flir PTU
* Use Python3 instead of Python
* Make pan/tilt test mode move a little more often
* Move TcpClient into its own class file. Improve ROS param setting.
* interim debugging params and msgs
* Added test mode to send random pan/tilt every few seconds
* fix launch file syntax error
* Adding feature/tcpConnection option for model PTU-D48E
* Contributors: Chris Iverach-Brereton, Joey Yang, Luis Camero, Mark Lewis, Tony Baltovski, luis-camero
```

## flir_ptu_viz

```
* Merge pull request #50 <https://github.com/ros-drivers/flir_ptu/issues/50> from ros-drivers/wip-simulation
  Add Gazebo Support
* Re-add the _viz package's launch tests
* Use a pair of JointPositionControllers to provide gazebo simulation support for the PTU
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```
