### PR TITLE
numato_relay_interface: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -651,6 +651,21 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
       version: 0.0.2-1
     status: maintained
+  numato_relay_interface:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/numato_relay_interface.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/numato_relay_interface-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/numato_relay_interface.git
+      version: master
+    status: maintained
   occupancy_grid_utils:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `numato_relay_interface` to `0.1.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/numato_relay_interface.git
- release repository: https://github.com/clearpath-gbp/numato_relay_interface-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## numato_relay_interface

```
* Initial public release
* Contributors: Chris Iverach-Brereton, Joey Yang, Rhys Faultless, Tony Baltovski
```
