### PR TITLE
video_recorder: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -898,7 +898,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/video_recorder-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/video_recorder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_recorder` to `0.0.5-1`:

- upstream repository: https://github.com/clearpathrobotics/video_recorder.git
- release repository: https://github.com/clearpath-gbp/video_recorder-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.4-1`

## audio_recorder

```
* Add ability to record meta-data about each recording
* Initial implementation of audio_recorder metadata to match the video_recorder implementation
* Create the output directory for the audio recorder node to keep the behaviour consistent with the video recorder
* Contributors: Chris Iverach-Brereton
```

## audio_recorder_msgs

- No changes

## video_recorder

```
* Add ability to record meta-data about each recording
* Add exception handling if the tf lookup fails
* Switch from Mat to UMat to allow OpenCL support
* Add a space after the zoom colon
* Include the ROS topic name in the metadata
* Update the readme, add preliminary zoom support
* Add first-draft support for recording the robot and camera poses whenever a video starts or image is saved
* Contributors: Chris Iverach-Brereton
```

## video_recorder_msgs

- No changes
