### PR TITLE
numato_relay_interface: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -660,7 +660,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/numato_relay_interface-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/numato_relay_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `numato_relay_interface` to `0.1.2-1`:

- upstream repository: https://github.com/clearpathrobotics/numato_relay_interface.git
- release repository: https://github.com/clearpath-gbp/numato_relay_interface-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## numato_relay_interface

```
* Fix required components in the cmake file, update the maintainer
* Contributors: Chris Iverach-Brereton
```
