### PR TITLE
jackal: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -52,7 +52,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `1.0.4-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## jackal_control

```
* Remove gravitational acceleration in ekf_node
* Contributors: Roni Kreinin
```

## jackal_description

```
* [jackal_description] Changed the output type of the gazebo_ros_ray_sensor to LaserScan.
* Contributors: Tony Baltovski
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
