### PR TITLE
dingo_robot: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -408,7 +408,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.3.1-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`

## dingo_base

```
* Adding Sick TIM551 lidar
* Added mapping for Dingo-D wheel names
* Contributors: Hilary Luo, Roni Kreinin
```

## dingo_bringup

```
* Adding Sick TIM551 lidar
* Updated realsense initial_reset
  Missing the prefix realsense_
* Contributors: Hilary Luo, luis-camero
```

## dingo_robot

- No changes
