### PR TITLE
ptz_action_server: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -691,12 +691,11 @@ repositories:
     release:
       packages:
       - axis_ptz_action_server
-      - flir_ptu_action_server
       - ptz_action_server_msgs
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ptz_action_server-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ptz_action_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ptz_action_server` to `0.1.2-1`:

- upstream repository: https://github.com/clearpathrobotics/ptz_action_server.git
- release repository: https://github.com/clearpath-gbp/ptz_action_server-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## axis_ptz_action_server

```
* Re-send the axis command if the camera isn't moving after 5s
* Add some additional logging, handle camera disconnections better
* Abort the action in-progress if the Axis camera stops publishing state messages
* Use format strings instead of .format
* Contributors: Chris Iverach-Brereton
```

## ptz_action_server_msgs

- No changes
