### PR TITLE
cpr_onav_description: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -302,11 +302,19 @@ repositories:
       version: noetic-devel
     status: developed
   cpr_onav_description:
+    doc:
+      type: git
+      url: https://github.com/cpr-application/cpr_onav_description.git
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_onav_description-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/cpr-application/cpr_onav_description.git
+      version: main
     status: maintained
   cpr_platform_tests:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_onav_description` to `0.1.1-1`:

- upstream repository: https://github.com/cpr-application/cpr_onav_description.git
- release repository: https://github.com/clearpath-gbp/cpr_onav_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## cpr_onav_description

```
* Added license file.
* remove circular dependency by adding local copies of accesory urdf files
* added charge receiver link
* Contributors: José Mastrangelo, Tony Baltovski
```
