### PR TITLE
cpr_platform_tests: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -328,7 +328,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/cpr_platform_tests-gbp.git
-      version: 0.3.2-1
+      version: 0.3.3-1
   cpr_robot_customizer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_platform_tests` to `0.3.3-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/cpr_platform_tests.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/cpr_platform_tests-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.2-1`

## boxer_tests

```
* Added front and rear e-stop test for Boxer.
* Update rotate test and drive test prompts to indicate that travel displacements are approximate
* Increase rotate test acceptable error since OTTO onboard IMU has low accuracy; remove unused response_delay variable
* Contributors: Joey Yang, Tony Baltovski
```

## dingo_tests

```
* Change references of E-Stop to Motion Stop for all platforms except for Boxer
* Increase passable voltage threshold from 20 to 25 percent
* Update rotate test and drive test prompts to indicate that travel displacements are approximate
* Contributors: Joey Yang
```

## husky_tests

```
* Change references of E-Stop to Motion Stop for all platforms except for Boxer
* Increase passable voltage threshold from 20 to 25 percent
* Update rotate test and drive test prompts to indicate that travel displacements are approximate
* Contributors: Joey Yang
```

## jackal_tests

```
* Change references of E-Stop to Motion Stop for all platforms except for Boxer
* Increase passable voltage threshold from 20 to 25 percent
* Remove current fields that are unimplemented at the firmware level
* Update rotate test and drive test prompts to indicate that travel displacements are approximate
* Contributors: Joey Yang
```

## ridgeback_tests

```
* Change references of E-Stop to Motion Stop for all platforms except for Boxer
* Increase passable voltage threshold from 20 to 25 percent
* Remove current fields that are unimplemented at the firmware level
* Update rotate test and drive test prompts to indicate that travel displacements are approximate
* Contributors: Joey Yang
```

## warthog_tests

```
* Change references of E-Stop to Motion Stop for all platforms except for Boxer
* Increase passable voltage threshold from 20 to 25 percent
* Remove current fields that are unimplemented at the firmware level
* Update rotate test and drive test prompts to indicate that travel displacements are approximate
* Contributors: Joey Yang
```
