### PR TITLE
jackal: 0.8.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -554,7 +554,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.8.7-3
+      version: 0.8.8-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.8-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.7-3`

## jackal_control

- No changes

## jackal_description

```
* change location of onav config
* added outdoornav enable variable and hardware kit selector for urdf
* Contributors: José Mastrangelo
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
