### PR TITLE
ridgeback: 0.3.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -741,7 +741,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.3.3-2
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.3.4-1`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.3-2`

## ridgeback_control

- No changes

## ridgeback_description

```
* Take the thickness of the deck into consideration so that the riser link has the correct origin and the top link sits atop it correctly. Change the riser colour to light grey to match the unfinished aluminium extrusion used for this component
* Initial commit of adding a customizable riser height to the URDF
* Contributors: Chris Iverach-Brereton
```

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
