### PR TITLE
microhard_snmp: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -657,7 +657,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     status: maintained
   numato_relay_interface:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `microhard_snmp` to `0.0.3-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/microhard_snmp.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## microhard_snmp

```
* Allow changing device ID
* Contributors: Michael Hosmar
```
