### PR TITLE
clearpath_msgs: 0.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -125,6 +125,32 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
       version: noetic-devel
     status: maintained
+  clearpath_msgs:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: noetic-devel
+    release:
+      packages:
+      - clearpath_configuration_msgs
+      - clearpath_control_msgs
+      - clearpath_dock_msgs
+      - clearpath_localization_msgs
+      - clearpath_mission_manager_msgs
+      - clearpath_mission_scheduler_msgs
+      - clearpath_msgs
+      - clearpath_navigation_msgs
+      - clearpath_platform_msgs
+      - clearpath_safety_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
+      version: 0.9.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: noetic-devel
+    status: maintained
   cpr_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `0.9.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_configuration_msgs

```
* Initial release
```

## clearpath_control_msgs

```
* Initial release
```

## clearpath_dock_msgs

```
* Initial release
```

## clearpath_localization_msgs

```
* Initial release
```

## clearpath_mission_manager_msgs

```
* Initial release
```

## clearpath_mission_scheduler_msgs

```
* Initial release
```

## clearpath_msgs

```
* Initial release
```

## clearpath_navigation_msgs

```
* Initial release
```

## clearpath_platform_msgs

```
* Initial release
```

## clearpath_safety_msgs

```
* Initial release
```
