### PR TITLE
clearpath_simulator: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -63,6 +63,25 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_msgs.git
       version: main
     status: developed
+  clearpath_simulator:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_simulator.git
+      version: main
+    release:
+      packages:
+      - clearpath_generator_gz
+      - clearpath_gz
+      - clearpath_simulator
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_simulator.git
+      version: main
+    status: developed
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `0.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_generator_gz

```
* Updated imports and getters
* Contributors: Luis Camero
```

## clearpath_gz

```
* [clearpath_gz] Removed ros_gz from CMakeLists.txt.
* Updated imports and getters
* Contributors: Luis Camero, Tony Baltovski
```

## clearpath_simulator

- No changes
