### PR TITLE
clearpath_nav2_demos: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -63,6 +63,21 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_msgs.git
       version: main
     status: developed
+  clearpath_nav2_demos:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
+      version: main
+    status: developed
   clearpath_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_nav2_demos` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
- release repository: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_nav2_demos

```
* Added space to package.xml.
* Updated package.xml order.
* Added test dependencies.
* Added Github actions.
* Config updates
* Namespacing fixes
* Updated odom topics
* Fixed footprint and adjusted velocity/accel limits on J100
* Use config to set namespace and platform model
* Current best parameters for Husky
* Cleanup
* Jackal params
* Initial commit
* Initial commit
* Contributors: Hilary Luo, Roni Kreinin, Tony Baltovski
```
