### PR TITLE
wireless: 1.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -107,9 +107,9 @@ repositories:
       - wireless_msgs
       - wireless_watcher
       tags:
-        release: release/foxy/{package}/{version}
+        release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 1.0.0-1
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.0.1-2`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## wireless_msgs

- No changes

## wireless_watcher

```
* [wireless_watcher] Switched to underscores to get rid of usage of dash-separated warning.
* Contributors: Tony Baltovski
```
