### PR TITLE
nmea_navsat_driver: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -97,6 +97,12 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_simulator.git
       version: main
     status: developed
+  nmea_navsat_driver:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
+      version: 2.0.0-1
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/nmea_navsat_driver.git
- release repository: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## nmea_navsat_driver

```
* Replace dependency on transforms3d pip package to tf_transformations. (#147 <https://github.com/evenator/nmea_navsat_driver/issues/147>)
* Added log for successful connection. (#149 <https://github.com/evenator/nmea_navsat_driver/issues/149>)
* Removed printing every time the checksum is checked. (#148 <https://github.com/evenator/nmea_navsat_driver/issues/148>)
* nmea_socket_driver fixes for ROS2 (#127 <https://github.com/evenator/nmea_navsat_driver/issues/127>)
  * Fix white space for PEP8 compliance
  * Fix socket driver for ROS2 Foxy
  * Add config file for socket driver
  * Decode bytes as ASCII
* Fix bug where ROS node is not assigned correctly (#114 <https://github.com/evenator/nmea_navsat_driver/issues/114>)
  Fixes #71 <https://github.com/evenator/nmea_navsat_driver/issues/71>
* Update launch file for ROS2 Foxy (#110 <https://github.com/evenator/nmea_navsat_driver/issues/110>)
  * Remove get_default_launch_description, which no longer exists.
  * Update the parameters of the Node initializer to the Foxy API.
* Update pyserial dependency to make it findable with rosdep (#109 <https://github.com/evenator/nmea_navsat_driver/issues/109>)
  This allows rosdep to find the correct serial package and install it.
* ROS2: Eloquent changes for python packages (#101 <https://github.com/evenator/nmea_navsat_driver/issues/101>)
  Fix some warnings when installing packages that first appear in ROS2 Eloquent:
  - A missing the resource folder
  - Not explicitly installing package.xml in the share folder.
* ROS2 updates for Dashing (#80 <https://github.com/evenator/nmea_navsat_driver/issues/80>)
  Change subscriptions and parameters to conform to API changes in ROS 2 Dashing.
* Remove scripts directory in favor of nodes subpackage (#77 <https://github.com/evenator/nmea_navsat_driver/issues/77>)
  Since these modules will no longer be called as scripts in ROS 2,
  move them to a nodes subpackage, and remove the option to call them
  as executables.
  Addresses #75 <https://github.com/evenator/nmea_navsat_driver/issues/75> for ROS 2.
* Fix nmea_topic_serial_reader name (#74 <https://github.com/evenator/nmea_navsat_driver/issues/74>)
  - Fix #72 <https://github.com/evenator/nmea_navsat_driver/issues/72> (no module name scripts.nmea_topic_serial_driver)
  - Fix exception handling in nmea_topic_serial_reader ('rclpy' has no attribute 'ROSInterruptException')
* Clean up launch file and make it runnable with ROS2 launch (#73 <https://github.com/evenator/nmea_navsat_driver/issues/73>)
  Fixes #70 <https://github.com/evenator/nmea_navsat_driver/issues/70>
  - Rename config file and put it into a config directory.
  - Make setup.py install the launch and config files.
  - Rename the launch file with the .launch.py suffix used by OSRF
  packages.
  - Refactor the launch file so that it works with ros2 launch.
* Fix PEP8 Violations and update setup.cfg file for pycodestyle. (#69 <https://github.com/evenator/nmea_navsat_driver/issues/69>)
* Port to ROS 2 (#64 <https://github.com/evenator/nmea_navsat_driver/issues/64>)
  Initial work to port nmea_navsat_driver to ROS2 by @klintan.
* Add nmea_serial_driver launch file (#60 <https://github.com/evenator/nmea_navsat_driver/issues/60>)
  Add example nmea_serial_driver launch file.
* Remove automatic prefixing of forward slash to frame_id. (#33 <https://github.com/evenator/nmea_navsat_driver/issues/33>/#57 <https://github.com/evenator/nmea_navsat_driver/issues/57>)
  To be consistent with the current default behavior, the default frame_id has been set to /gps with the prepended forward slash.
* Add support for IMU aided GPS systems (#30 <https://github.com/evenator/nmea_navsat_driver/issues/30>/#58 <https://github.com/evenator/nmea_navsat_driver/issues/58>)
  * Add support for IMU aided GPS systems like the Applanix POS/MV, whose NMEA strings typically begin '$IN'. (e.g. $INGGA).
  * Add support for VTG messages, which contain Course Over Ground and Speed Made Good. These are useful when not using RMC messages and you don't have a heading sensor.
* Add support for publishing heading from GPHDT as a QuaternionStamped message on the topic /heading (#25 <https://github.com/evenator/nmea_navsat_driver/issues/25>)
* Improve Covariance Estimation (#46 <https://github.com/evenator/nmea_navsat_driver/issues/46>)
  Use GST covariance where available, otherwise uses default covariances estimated from fix type.
  The previous implementation set covariance to HDOP^2. Instead, it should multiply that by the measurement variance. HDOP should be greater than 1.0.
* Add Socket Driver (#32 <https://github.com/evenator/nmea_navsat_driver/issues/32>)
  Add a NMEA socket driver node, which is like the existing serial driver node, but instead of attaching to a TTY handle from a serial port, it listens to a UDP port for NMEA sentences.
* Add code to handle serial exception to allow node to exit cleanly (#52 <https://github.com/evenator/nmea_navsat_driver/issues/52>)
  - Catch Serial exceptions and exit cleanly, instead of printing Python stack trace.
  - Catch Serial exception when opening the serial port, log a FATAL message, and exit instead of printing Python stack trace.
* Remove MSL compensation (#36 <https://github.com/evenator/nmea_navsat_driver/issues/36>)
  Fix for #29 <https://github.com/evenator/nmea_navsat_driver/issues/29> Altitude vs Elipsoid Height.
* Add GLONASS support
  GLONASS capable devices send different NMEA sentences, which are
  basically identical to the GPS sentences, but with other prefixes.
* Updated driver to accept status of 9 which some novatel receivers report for a WAAS (SBAS) fix.
  See http://www.novatel.com/support/known-solutions/which-novatel-position-types-correspond-to-the-gga-quality-indicator/
```
