### PR TITLE
flir_camera_driver: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -97,6 +97,25 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_simulator.git
       version: main
     status: developed
+  flir_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_camera_driver.git
+      version: humble-devel
+    release:
+      packages:
+      - flir_camera_description
+      - flir_camera_msgs
+      - spinnaker_camera_driver
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_camera_driver.git
+      version: humble-devel
+    status: maintained
   nmea_navsat_driver:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## flir_camera_description

```
* [flir_camera_description] Changed unused depends to exec_depends.
* Merge pull request #113 <https://github.com/ros-drivers/flir_camera_driver/issues/113> from berndpfrommer/humble-devel-new
  new driver for ROS2
* resize image and move to top
* update licensing comment
* modify the description package for ROS2, add documentation
* Contributors: Bernd Pfrommer, Tony Baltovski
```

## flir_camera_msgs

```
* Merge pull request #113 <https://github.com/ros-drivers/flir_camera_driver/issues/113> from berndpfrommer/humble-devel-new
  new driver for ROS2
* more elaborate README
* added flir_camera_msgs package
* Contributors: Bernd Pfrommer, Tony Baltovski
```

## spinnaker_camera_driver

```
* Merge pull request #113 <https://github.com/ros-drivers/flir_camera_driver/issues/113> from berndpfrommer/humble-devel-new
  new driver for ROS2
* added spinnaker_camera_driver package
* deleted spinnaker ros2 driver, to be replaced by new version
* Contributors: Bernd Pfrommer, Tony Baltovski
```
