### PR TITLE
clearpath_robot: 0.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -78,6 +78,25 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
       version: main
     status: developed
+  clearpath_robot:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_robot.git
+      version: main
+    release:
+      packages:
+      - clearpath_generator_robot
+      - clearpath_robot
+      - clearpath_sensors
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_robot-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_robot.git
+      version: main
+    status: developed
   clearpath_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.0.1-2`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_generator_robot

```
* Set use_sim_time to false
* Updated namespace and domain id service call
* Updates for how launch files are written
* Namespacing support
* Moved clearpath_platform to clearpath_common
  Added clearpath_generator_robot
  Created clearpath_robot metapackage
  Moved scripts and services into clearpath_robot
* Contributors: Roni Kreinin
```

## clearpath_robot

```
* [clearpath_platform] Added J100 MCU, FTDI and Logitech joy udev rules.
* Moved clearpath_platform to clearpath_common
  Added clearpath_generator_robot
  Created clearpath_robot metapackage
  Moved scripts and services into clearpath_robot
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_sensors

```
* Namespacing support
* Linter fix
* IMU and VLP fix
* Bishop sensors
* Licenses
  sick launch
* Added microstrain
* Fixed namespacing
* Remove old generated files before generating again
  Pass topic namespace to nodes
  Added velodyne
* realsense
* Simplified launch generation
  Added robot launch
* Initial working launch generator
* Contributors: Roni Kreinin
```
