### PR TITLE
micro_ros_msgs: 3.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -135,6 +135,12 @@ repositories:
       url: https://github.com/ros-drivers/flir_camera_driver.git
       version: humble-devel
     status: maintained
+  micro_ros_msgs:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/micro_ros_msgs-release.git
+      version: 3.0.0-1
   nmea_navsat_driver:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_msgs` to `3.0.0-1`:

- upstream repository: https://github.com/micro-ROS/micro_ros_msgs.git
- release repository: https://github.com/clearpath-gbp/micro_ros_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## micro_ros_msgs

- No changes
