### PR TITLE
clearpath_common: 0.0.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -24,7 +24,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.0.7-1
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `0.0.8-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.7-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Linting
* use_sim_time support
* Description and Bash generator cleanup
* Minor cleanup
* Param generator
* Launch generator cleanup
* Contributors: Roni Kreinin
```

## clearpath_mounts_description

- No changes

## clearpath_platform

- No changes

## clearpath_platform_description

```
* Updated J100 imu and navsat links
* Contributors: Roni Kreinin
```

## clearpath_sensors_description

- No changes
