### PR TITLE
clearpath_robot: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -91,7 +91,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-2`

## clearpath_generator_robot

```
* Sensor namespace
* Param generator
* Launch generator cleanup
* NMEA navsat driver
* Import paths
* Contributors: Roni Kreinin
```

## clearpath_robot

```
* Config update
* Contributors: Roni Kreinin
```

## clearpath_sensors

```
* Sensor namespace
* Microstrain namespacing
  LMS1xx parameters
* Contributors: Roni Kreinin
```
