### PR TITLE
umx_drver: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -159,6 +159,23 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/serial-release.git
       version: 2.0.0-1
+  umx_drver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: ros2
+    release:
+      packages:
+      - umx_driver
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um7-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: ros2
+    status: end-of-life
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `umx_drver` to `1.0.0-1`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## umx_driver

```
* Reverted versioning to continue where it left off
* Add instructions and update log for ros 2 version
* Fixed inclusion of serial library in CI
* Updated CI setup-ros tooling version
* Add github ci
* Setup custom tests
* Linting changes
* Updated test files
* Updating for ROS 2 Linting
* Updating to hpp file naming for linting
* Added UM6_driver
* Optimized for speed
* Update structure for separateUM6 and 7 nodes
* More detailed error message
* Setup for ROS 2 and UM7
* folder structure for new executable name
* folder structure for new package name
* Contributors: Hilary Luo
```
