### PR TITLE
cpr_onav_description: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -336,7 +336,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_onav_description-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/cpr-application/cpr_onav_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_onav_description` to `0.1.3-1`:

- upstream repository: https://github.com/cpr-application/cpr_onav_description.git
- release repository: https://github.com/clearpath-gbp/cpr_onav_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## cpr_onav_description

```
* fix: move lms1xx link back into correct location. this bug was resolve in the intall script. update hokuyo prefix
* Contributors: José Mastrangelo
```
