### PR TITLE
umx_driver: 1.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -165,12 +165,10 @@ repositories:
       url: https://github.com/ros-drivers/um7.git
       version: ros2
     release:
-      packages:
-      - umx_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/um7-release.git
-      version: 1.0.0-1
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/ros-drivers/um7.git


### PR DESCRIPTION
Increasing version of package(s) in repository `umx_driver` to `1.0.1-2`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## umx_driver

```
* Added boost as a build_depend.
* Contributors: Tony Baltovski
```
