### PR TITLE
umx_driver: 1.0.1-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -159,6 +159,12 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/serial-release.git
       version: 2.0.0-1
+  umx_driver:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um7-release.git
+      version: 1.0.1-3
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `umx_driver` to `1.0.1-3`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## umx_driver

```
* Added boost as a build_depend.
* Contributors: Tony Baltovski
```
