### PR TITLE
clearpath_config: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -39,7 +39,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.0.5-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.4-1`

## clearpath_config

```
* Split novatel GPS
* PyTest issues
* Linter issues
* Node names and flatten dictionaries
* Added ros_parameters to extras
* Added Garmin and Novatel gps
* Added node names to rosparameters in sensors
* Update hostname and namespace to match serial
* Resolved indexing issue
* Contributors: Luis Camero
```
