### PR TITLE
ptz_action_server: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -726,10 +726,11 @@ repositories:
       packages:
       - axis_ptz_action_server
       - ptz_action_server_msgs
+      - simulated_ptz_action_server
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ptz_action_server-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ptz_action_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ptz_action_server` to `0.1.3-1`:

- upstream repository: https://github.com/clearpathrobotics/ptz_action_server.git
- release repository: https://github.com/clearpath-gbp/ptz_action_server-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## axis_ptz_action_server

- No changes

## ptz_action_server_msgs

- No changes

## simulated_ptz_action_server

```
* Add the simulated PTZ action server package for Gazebo support
* Contributors: Chris Iverach-Brereton
```
