### PR TITLE
clearpath_robot: 0.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -91,7 +91,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.0.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## clearpath_generator_robot

```
* Removed micros-ros-agent as dep.
* Renamed UST10 to UST
  Cleaned up generators
* Move author in all package.xml to pass xml linter.
* [clearpath_generator_robot] Added author to package.xml.
* Added UM6/7
* Added Garmin 18x, Smart6 and Smart7
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_robot

```
* Linter
* Move author in all package.xml to pass xml linter.
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_sensors

```
* Renamed UST10 to UST
  Cleaned up generators
* Fixed umx ports
* Move author in all package.xml to pass xml linter.
* Added UM6/7
* Updated default port for generic gps
* Added Garmin 18x, Smart6 and Smart7
* Contributors: Roni Kreinin, Tony Baltovski
```
