### PR TITLE
realsense_ros: 2.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -754,6 +754,24 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: master
     status: maintained
+  realsense_ros:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/realsense_ros.git
+      version: ros1-legacy
+    release:
+      packages:
+      - realsense2_camera
+      - realsense2_description
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/realsense_ros-release.git
+      version: 2.3.3-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/realsense_ros.git
+      version: ros1-legacy
+    status: unmaintained
   ridgeback:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_ros` to `2.3.3-1`:

- upstream repository: https://github.com/clearpathrobotics/realsense_ros.git
- release repository: https://github.com/clearpath-gbp/realsense_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## realsense2_camera

```
* Merge branch 'scottnothing-package-includes' into development
* Allow the catkin package to be included in other projects
* Merge pull request #2239 <https://github.com/clearpathrobotics/realsense_ros/issues/2239> from fredotran/development
  fix std::find_if issues
* fix std::find_if issues
* Merge pull request #2235 <https://github.com/clearpathrobotics/realsense_ros/issues/2235> from doronhi/fix_metadata_timestamp
  Fix Metadata timestamps
* set metadata messages header time stamp to match images time stamp.
* Contributors: Frederic Tran, Terry Scott, doronhi
```

## realsense2_description

```
* PR #1637 <https://github.com/clearpathrobotics/realsense_ros/issues/1637> from LuAPi: Add include guard to materials
* Add include guard to materials
  Prevents material already defined errors when adding multiple types of camera to a robot
* Contributors: Luke Pitt, Nir Azkiel
```
