### PR TITLE
cpr_onav_description: 0.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -336,7 +336,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_onav_description-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/cpr-application/cpr_onav_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_onav_description` to `0.1.5-1`:

- upstream repository: https://github.com/cpr-application/cpr_onav_description.git
- release repository: https://github.com/clearpath-gbp/cpr_onav_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-1`

## cpr_onav_description

```
* Add support for Husky Observer
* Add a new macro for the GNSS antennas, including collision bodies
* Add Husky Observer backpack model, Q62 meshes, support for observer configuration
* Fix the path for the Hokuyo mesh, add simplified collision geometry
* Contributors: Chris Iverach-Brereton
```
