### PR TITLE
clearpath_msgs: 0.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -145,7 +145,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `0.9.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.0-1`

## clearpath_configuration_msgs

- No changes

## clearpath_control_msgs

- No changes

## clearpath_dock_msgs

```
* Add message field to service response
* Added error message to service response
* Contributors: José Mastrangelo
```

## clearpath_localization_msgs

- No changes

## clearpath_mission_manager_msgs

- No changes

## clearpath_mission_scheduler_msgs

- No changes

## clearpath_msgs

- No changes

## clearpath_navigation_msgs

```
* Add comments to Waypoint message to match documentation
* Added Metrics.msg
* Contributors: Chris Iverach-Brereton, José Mastrangelo
```

## clearpath_platform_msgs

```
* Add the stack light messages to the platform messages
* Contributors: Chris Iverach-Brereton, José Mastrangelo
```

## clearpath_safety_msgs

- No changes
