### PR TITLE
clearpath_microhard_gateway: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -125,6 +125,13 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
       version: noetic-devel
     status: maintained
+  clearpath_microhard_gateway:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/clearpath_microhard_gateway-gbp.git
+      version: 0.0.1-1
+    status: maintained
   clearpath_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_microhard_gateway` to `0.0.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/clearpath_microhard_gateway.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/clearpath_microhard_gateway-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_microhard_gateway

```
* Initial Release
* Contributors: Michael Hosmar, Mike Hosmar
```
