### PR TITLE
husky_observer: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -553,6 +553,31 @@ repositories:
       url: https://github.com/husky/husky.git
       version: noetic-devel
     status: maintained
+  husky_observer:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/husky_observer.git
+      version: devel
+    release:
+      packages:
+      - husky_observer
+      - husky_observer_bringup
+      - husky_observer_diagnostics
+      - husky_observer_disk_mgmt
+      - husky_observer_disk_mgmt_msgs
+      - husky_observer_power_mgmt
+      - husky_observer_safety_alarm
+      - husky_observer_stack_light
+      - husky_observer_tests
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/husky_observer.git
+      version: devel
+    status: developed
   husky_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_observer` to `0.0.2-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/husky_observer.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## husky_observer

- No changes

## husky_observer_bringup

```
* Clean package dependencies
  * Remove the video_recorder dependency since we don't launch video_recorder nodes from here
  * Remove dependencies on the NEC, wibotic, and pdu packages; we don't launch them from packageshere and their services can be provided by other sources
* Fix the install path of the peak udev rule
* Fix audio recorder output filepath to save in same location as video/images
* Contributors: Chris Iverach-Brereton, José Mastrangelo
```

## husky_observer_diagnostics

- No changes

## husky_observer_disk_mgmt

- No changes

## husky_observer_disk_mgmt_msgs

- No changes

## husky_observer_power_mgmt

- No changes

## husky_observer_safety_alarm

- No changes

## husky_observer_stack_light

- No changes

## husky_observer_tests

```
* Remove the PDU dependency from the tests
* Remove dependencies on the NEC, wibotic, and pdu packages; we don't launch them from packages here and their services can be provided by other sources
* Contributors: Chris Iverach-Brereton
```
