### PR TITLE
clearpath_desktop: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -45,6 +45,25 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git
       version: main
     status: maintained
+  clearpath_desktop:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_desktop.git
+      version: main
+    release:
+      packages:
+      - clearpath_config_live
+      - clearpath_desktop
+      - clearpath_viz
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_desktop.git
+      version: main
+    status: developed
   clearpath_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_config_live

- No changes

## clearpath_desktop

- No changes

## clearpath_viz

```
* Update scan topic to match other packages
* Contributors: Hilary Luo
* Update scan topic to match other packages
* Contributors: Hilary Luo
```
