### PR TITLE
micro_ros_agent: 3.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -159,7 +159,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/micro-ROS-Agent-release.git
-      version: 3.0.5-1
+      version: 3.0.6-1
   micro_ros_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_agent` to `3.0.6-1`:

- upstream repository: https://github.com/clearpathrobotics/micro-ROS-Agent.git
- release repository: https://github.com/clearpath-gbp/micro-ROS-Agent-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.5-1`

## micro_ros_agent

```
* Fix superbuild install permission errors
* Contributors: Błażej Sowa
```
