### PR TITLE
microhard_snmp: 0.0.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -715,7 +715,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     status: maintained
   numato_relay_interface:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `microhard_snmp` to `0.0.7-1`:

- upstream repository: git@gitlab.clearpathrobotics.com:research/microhard_snmp.git
- release repository: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.6-1`

## microhard_snmp

```
* Fix: Handle edge cases for throughput unit parsing
  - Previous method relied on the 'units' component being 2 characters which would cause crashes when the incoming value was in bytes (e.g., 100.0B)
* Contributors: Stephen Phillips
```
