### PR TITLE
husky_observer: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -572,7 +572,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/husky_observer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_observer` to `0.0.4-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/husky_observer.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.3-1`

## husky_observer

- No changes

## husky_observer_bringup

```
* Slow rotation even more
* Add the cron job to fix the clearpath_files directory permissions
* Unset the wibotic bumper envar as this removes the standard front bumper
* Contributors: Chris Iverach-Brereton, Michael Hosmar
```

## husky_observer_diagnostics

```
* Add support for single & dual lidar diagnostics based on envar.
* Add additional topic diagnostics to check for BMS, PDU, and MCU
* Contributors: Chris Iverach-Brereton
```

## husky_observer_disk_mgmt

- No changes

## husky_observer_disk_mgmt_msgs

- No changes

## husky_observer_power_mgmt

```
* Update the comment block explaining the PDU connections for low-power mode
* Turn off VBATT when entering low-power mode
* Contributors: Chris Iverach-Brereton
```

## husky_observer_safety_alarm

- No changes

## husky_observer_stack_light

```
* Add a readme for the stack light control node
* Contributors: Chris Iverach-Brereton
```

## husky_observer_tests

- No changes
