### PR TITLE
video_recorder: 0.0.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -982,7 +982,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/video_recorder-release.git
-      version: 0.0.8-1
+      version: 0.0.9-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/video_recorder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_recorder` to `0.0.9-1`:

- upstream repository: https://github.com/clearpathrobotics/video_recorder.git
- release repository: https://github.com/clearpath-gbp/video_recorder-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.8-1`

## audio_recorder

```
* Don't abort if we get a double-record or double-stop; treat these as successesful action invocation (but with .success set to false to indicate no new recording was made) and send the existing path if appropriate.
* Contributors: Chris Iverach-Brereton
```

## audio_recorder_msgs

- No changes

## video_recorder

```
* Don't abort if we get a double-record or double-stop; treat these as successesful action invocation (but with .success set to false to indicate no new recording was made) and send the existing path if appropriate.
* Contributors: Chris Iverach-Brereton
```

## video_recorder_msgs

- No changes
