### PR TITLE
flir_ptu: 0.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -511,7 +511,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/flir_ptu-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_ptu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.2.3-1`:

- upstream repository: https://github.com/ros-drivers/flir_ptu.git
- release repository: https://github.com/clearpath-gbp/flir_ptu-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## flir_ptu_description

- No changes

## flir_ptu_driver

```
* Expose joint_name_prefix as an arg in the launch file.  This makes it easier to add multiple PTUs.
* Contributors: Chris Iverach-Brereton
```

## flir_ptu_viz

- No changes
