### PR TITLE
clearpath_microhard_gateway: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -130,7 +130,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/clearpath_microhard_gateway-gbp.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     status: maintained
   clearpath_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_microhard_gateway` to `0.0.2-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/clearpath_microhard_gateway.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/clearpath_microhard_gateway-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`

## clearpath_microhard_gateway

```
* Merge branch 'ssh-again' into 'main'
  Use SSH to change load balancer priority and to monitor current proportion
  See merge request research/clearpath_microhard_gateway!2
* Contributors: Michael Hosmar, Mike Hosmar
```
