### PR TITLE
warthog: 0.1.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1001,7 +1001,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.1.7-1
+      version: 0.1.8-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.8-1`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.7-1`

## warthog_control

```
* [warthog_contorl] Updated diff_drive_controller parameters.
* Contributors: Tony Baltovski
```

## warthog_description

- No changes

## warthog_msgs

- No changes
