### PR TITLE
clearpath_msgs: 0.9.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -152,7 +152,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `0.9.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.1-1`

## clearpath_configuration_msgs

```
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton
```

## clearpath_control_msgs

```
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton
```

## clearpath_dock_msgs

```
* Use raw JSON strings for import & export; don't bother gzipping & base-64 encoding them
* Add import/export services for docking
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton
```

## clearpath_localization_msgs

```
* Add: .srv definition for ConvertCartesianToLatLon service
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton, Stephen Phillips, Jose Mastrangelo
```

## clearpath_mission_manager_msgs

```
* Use raw JSON strings for import & export; don't bother gzipping & base-64 encoding them
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton
```

## clearpath_mission_scheduler_msgs

```
* Use raw JSON strings for import & export; don't bother gzipping & base-64 encoding them
* Contributors: Chris Iverach-Brereton
```

## clearpath_msgs

```
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton
```

## clearpath_navigation_msgs

```
* [ONAV-1546] Add autonomy API option to start mission from current position
  - Changes to the ExecuteMissionByUuid.action and Mission.action to support 'Resuming' missions and starting missions from specified waypoints.
  - The combination of the 'from_start' and 'start_waypoint' field determine the behavior:
  - from_start == True will always force the mission to run from the beginning
  - from_start == False AND start_waypoint_uuid/start_waypoint == Null will let autonomy decide where to start the mission ('closest' waypoint)
  - from_start == False AND start_waypoint_uuid/start_waypoint != Null will tell autonomy to start the mission from the specified waypoint (useful in area-coverage type applications)
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton, Stephen Phillips, Tony Baltovski
```

## clearpath_platform_msgs

```
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton
```

## clearpath_safety_msgs

```
* Fix over & underline length in changelogs
* Contributors: Chris Iverach-Brereton
```
