### PR TITLE
Change branch for numato_relay_interface

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -721,7 +721,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/clearpathrobotics/numato_relay_interface.git
-      version: main
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -730,7 +730,7 @@ repositories:
     source:
       type: git
       url: https://github.com/clearpathrobotics/numato_relay_interface.git
-      version: main
+      version: noetic-devel
     status: maintained
   occupancy_grid_utils:
     release:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -717,19 +717,19 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
       version: 0.0.8-2
     status: maintained
-  numato_relay_interface:
+  numato_relay:
     doc:
       type: git
-      url: https://github.com/clearpathrobotics/numato_relay_interface.git
+      url: https://github.com/clearpathrobotics/numato_relay.git
       version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/clearpath-gbp/numato_relay_interface-release.git
+      url: https://github.com/clearpath-gbp/numato_relay-release.git
       version: 0.1.3-1
     source:
       type: git
-      url: https://github.com/clearpathrobotics/numato_relay_interface.git
+      url: https://github.com/clearpathrobotics/numato_relay.git
       version: noetic-devel
     status: maintained
   occupancy_grid_utils:


### PR DESCRIPTION
We're adding humble support to the Numato Relay Interface package, so the Noetic branch is changing from `main` to `noetic-devel`