### PR TITLE
numato_relay: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -726,7 +726,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/numato_relay-release.git
-      version: 0.1.3-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/numato_relay.git


### PR DESCRIPTION
Increasing version of package(s) in repository `numato_relay` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/numato_relay.git
- release repository: https://github.com/clearpath-gbp/numato_relay-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.3-1`

## numato_relay

```
* Rename the package from numato_relay_interface to numato_relay
* Add a notice about supported devices & ROS version
* Contributors: Chris Iverach-Brereton
```
