### PR TITLE
clearpath_onav_examples: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -158,6 +158,25 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_msgs.git
       version: noetic-devel
     status: maintained
+  clearpath_onav_examples:
+    doc:
+      type: git
+      url: https://github.com/cpr-application/clearpath_onav_examples.git
+      version: main
+    release:
+      packages:
+      - clearpath_onav_api_examples
+      - clearpath_onav_api_examples_lib
+      - clearpath_onav_examples
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_onav_examples-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/cpr-application/clearpath_onav_examples.git
+      version: main
+    status: maintained
   cpr_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_onav_examples` to `0.0.2-1`:

- upstream repository: https://github.com/cpr-application/clearpath_onav_examples.git
- release repository: https://github.com/clearpath-gbp/clearpath_onav_examples-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_onav_api_examples

- No changes

## clearpath_onav_api_examples_lib

```
* Modify the coordinate_lat_lon class to use pyproj instead of the utm package
* Contributors: José Mastrangelo
```

## clearpath_onav_examples

- No changes
