### PR TITLE
clearpath_simulator: 0.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -129,7 +129,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `0.1.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## clearpath_generator_gz

- No changes

## clearpath_gz

```
* closes #16 <https://github.com/clearpathrobotics/clearpath_simulator/issues/16> (#17 <https://github.com/clearpathrobotics/clearpath_simulator/issues/17>)
  Fixes Lidar rays when running without a GPU, still works with GPU
* Contributors: Arthur Gomes
```

## clearpath_simulator

- No changes
