### PR TITLE
clearpath_onav_examples: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -171,7 +171,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_onav_examples-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/cpr-application/clearpath_onav_examples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_onav_examples` to `0.0.4-1`:

- upstream repository: https://github.com/cpr-application/clearpath_onav_examples.git
- release repository: https://github.com/clearpath-gbp/clearpath_onav_examples-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.3-1`

## clearpath_onav_api_examples

- No changes

## clearpath_onav_api_examples_lib

```
* Fix adding tasks to waypoints
* Added updates to Mission action and Task failure
* Added from_start and start_waypoint defaults
* Remove default values for start_waypoint_num and from_start mission argument
* Added allow_failure to Task class. Fix ordering of defualt parameters of MIsion class
* Added from_start and start waypoint information to Mission class
* Contributors: José Mastrangelo
```

## clearpath_onav_examples

- No changes
