### PR TITLE
ptz_action_server: 0.1.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -800,7 +800,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ptz_action_server-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ptz_action_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ptz_action_server` to `0.1.6-1`:

- upstream repository: https://github.com/clearpathrobotics/ptz_action_server.git
- release repository: https://github.com/clearpath-gbp/ptz_action_server-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.5-1`

## axis_ptz_action_server

```
* Major overhaul to add new control modes (#4 <https://github.com/clearpathrobotics/ptz_action_server/issues/4>)
  * Rename PtzPosition.msg to PtzState.msg, add support for velocity control. Rename .../move_ptz action to .../position, add .../velocity to Axis camera to allow velocity control
  * Add support for move_ptz/position_abs and move_ptz/position_rel actions
  * Update the readme
  * Add support for absolute & relative positions for the flir PTU
  * Move the axis server's actions into the move_ptz namespace, add position_abs and position_rel
  * Update the limits config files, readme for the axis action server
  * Keep all nodes called "ptz_action_server_node" for all nodes by default to make searching params easier
  * Make the ROS parameters consistent across all implementations. Add limits file for the simulation node
  * Publish the sign of the direction of travel in velocity control feedback. Check if the camera has reached end-of-travel and signal the end of the velocity control action if this occurs
  * Debug the new action servers on actual hardware
  * Add the first-pass at supporting pan/tilt angles relative to an external frame. Not yet supported by the Flir PTU
  * Create a temporary vector frame we can use to calculate the necessary pan/tilt angles, rather than ignoring the tilt. This should allow the camera to operate correctly even on hills. Temporary frame has a UUID in the name so it shouldn't conflict with other frames in the robot
  * Modify the axis & simulation packages to use positive pan = clockwise instead of anticlockwise. Add a new action to pan/tilt/zoom to a specific frame
  * Fix message dependencies
  * Implement the new action to point the camera AT a specific frame, instead of just parallel with its X axis
* Contributors: Chris Iverach-Brereton
```

## flir_ptu_action_server

```
* Major overhaul to add new control modes (#4 <https://github.com/clearpathrobotics/ptz_action_server/issues/4>)
  * Rename PtzPosition.msg to PtzState.msg, add support for velocity control. Rename .../move_ptz action to .../position, add .../velocity to Axis camera to allow velocity control
  * Add support for move_ptz/position_abs and move_ptz/position_rel actions
  * Update the readme
  * Add support for absolute & relative positions for the flir PTU
  * Move the axis server's actions into the move_ptz namespace, add position_abs and position_rel
  * Update the limits config files, readme for the axis action server
  * Keep all nodes called "ptz_action_server_node" for all nodes by default to make searching params easier
  * Make the ROS parameters consistent across all implementations. Add limits file for the simulation node
  * Publish the sign of the direction of travel in velocity control feedback. Check if the camera has reached end-of-travel and signal the end of the velocity control action if this occurs
  * Debug the new action servers on actual hardware
  * Add the first-pass at supporting pan/tilt angles relative to an external frame. Not yet supported by the Flir PTU
  * Create a temporary vector frame we can use to calculate the necessary pan/tilt angles, rather than ignoring the tilt. This should allow the camera to operate correctly even on hills. Temporary frame has a UUID in the name so it shouldn't conflict with other frames in the robot
  * Modify the axis & simulation packages to use positive pan = clockwise instead of anticlockwise. Add a new action to pan/tilt/zoom to a specific frame
  * Fix message dependencies
  * Implement the new action to point the camera AT a specific frame, instead of just parallel with its X axis
* Contributors: Chris Iverach-Brereton
```

## ptz_action_server_msgs

```
* Major overhaul to add new control modes (#4 <https://github.com/clearpathrobotics/ptz_action_server/issues/4>)
  * Rename PtzPosition.msg to PtzState.msg, add support for velocity control. Rename .../move_ptz action to .../position, add .../velocity to Axis camera to allow velocity control
  * Add support for move_ptz/position_abs and move_ptz/position_rel actions
  * Update the readme
  * Add support for absolute & relative positions for the flir PTU
  * Move the axis server's actions into the move_ptz namespace, add position_abs and position_rel
  * Update the limits config files, readme for the axis action server
  * Keep all nodes called "ptz_action_server_node" for all nodes by default to make searching params easier
  * Make the ROS parameters consistent across all implementations. Add limits file for the simulation node
  * Publish the sign of the direction of travel in velocity control feedback. Check if the camera has reached end-of-travel and signal the end of the velocity control action if this occurs
  * Debug the new action servers on actual hardware
  * Add the first-pass at supporting pan/tilt angles relative to an external frame. Not yet supported by the Flir PTU
  * Create a temporary vector frame we can use to calculate the necessary pan/tilt angles, rather than ignoring the tilt. This should allow the camera to operate correctly even on hills. Temporary frame has a UUID in the name so it shouldn't conflict with other frames in the robot
  * Modify the axis & simulation packages to use positive pan = clockwise instead of anticlockwise. Add a new action to pan/tilt/zoom to a specific frame
  * Fix message dependencies
  * Implement the new action to point the camera AT a specific frame, instead of just parallel with its X axis
* Contributors: Chris Iverach-Brereton
```

## simulated_ptz_action_server

```
* Major overhaul to add new control modes (#4 <https://github.com/clearpathrobotics/ptz_action_server/issues/4>)
  * Rename PtzPosition.msg to PtzState.msg, add support for velocity control. Rename .../move_ptz action to .../position, add .../velocity to Axis camera to allow velocity control
  * Add support for move_ptz/position_abs and move_ptz/position_rel actions
  * Update the readme
  * Add support for absolute & relative positions for the flir PTU
  * Move the axis server's actions into the move_ptz namespace, add position_abs and position_rel
  * Update the limits config files, readme for the axis action server
  * Keep all nodes called "ptz_action_server_node" for all nodes by default to make searching params easier
  * Make the ROS parameters consistent across all implementations. Add limits file for the simulation node
  * Publish the sign of the direction of travel in velocity control feedback. Check if the camera has reached end-of-travel and signal the end of the velocity control action if this occurs
  * Debug the new action servers on actual hardware
  * Add the first-pass at supporting pan/tilt angles relative to an external frame. Not yet supported by the Flir PTU
  * Create a temporary vector frame we can use to calculate the necessary pan/tilt angles, rather than ignoring the tilt. This should allow the camera to operate correctly even on hills. Temporary frame has a UUID in the name so it shouldn't conflict with other frames in the robot
  * Modify the axis & simulation packages to use positive pan = clockwise instead of anticlockwise. Add a new action to pan/tilt/zoom to a specific frame
  * Fix message dependencies
  * Implement the new action to point the camera AT a specific frame, instead of just parallel with its X axis
* Contributors: Chris Iverach-Brereton
```
