### PR TITLE
husky_observer: 0.0.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -613,7 +613,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
-      version: 0.0.10-1
+      version: 0.0.11-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/husky_observer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_observer` to `0.0.11-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/husky_observer.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.10-1`

## husky_observer

- No changes

## husky_observer_bringup

- No changes

## husky_observer_diagnostics

```
* Rename the RealSense image topics to /image instead of /image_raw
* Contributors: Chris Iverach-Brereton
```

## husky_observer_disk_mgmt

- No changes

## husky_observer_disk_mgmt_msgs

- No changes

## husky_observer_power_mgmt

- No changes

## husky_observer_safety_alarm

- No changes

## husky_observer_stack_light

- No changes

## husky_observer_tests

- No changes
