### PR TITLE
canfestival_ros: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - jammy
 repositories:
+  canfestival_ros:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
+      version: ros2
+    status: maintained
   clearpath_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canfestival_ros` to `1.0.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## canfestival_ros

```
* Removed CMakeLists.txt logging message.
* Initial pass at ROS 2 targetting Humble.
* Contributors: Tony Baltovski
```
