### PR TITLE
sevcon_ros: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -193,6 +193,24 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/serial-release.git
       version: 2.0.0-1
+  sevcon_ros:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: ros2
+    release:
+      packages:
+      - sevcon_ros
+      - sevcon_traction
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: ros2
+    status: maintained
   umx_driver:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `1.0.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## sevcon_ros

```
* Initial pass at ROS 2.
* Contributors: Tony Baltovski
```

## sevcon_traction

```
* Initial pass at ROS 2.
* Contributors: Tony Baltovski
```
