### PR TITLE
canfestival_ros: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -15,7 +15,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `canfestival_ros` to `1.0.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## canfestival_ros

```
* Reduced logging.
* Contributors: Tony Baltovski
```
