### PR TITLE
clearpath_config: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -54,7 +54,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## clearpath_config

```
* Added wheel parameter to platform
* Fixed typo
* Added dd150 samples
* Added dd100 samples
* Fixed origin of pacs mounts
* Renamed SLA on Dingo
* Added entries for all dingo
* Updated sample to match attachments rework
* Fixed merge issues
* Added more warthog samples
* Updated sample default_mount
* Removed duplicate
* Added W200 attachments
* Updated default mounts on j100
* Updated default mounts on a200
* Changed default parent link to default_mount
* Changed the parent link of attachments
* Removed blannk line
* Removed top_plate from tests
* Updated samples
* Common attachments accross platforms
* Concatenate lists
* Updated all platform attachments
* Updated base attachment
* Attachments now list
* Updated Attachments to more genric case
* Removed specific attachment classes
* Remove all from list
* Accessory from/to dict
* Fixed long line for linter
* Moved username out of ros2 section
* Re-define DEFAULTS based on platform
* Detailed errors
* Fixed typo in samples
* Updated battery model
* Switched configurations
* Update commit
* Revert "Added battery to platform"
  This reverts commit fce11835ca8d6c477890084761075b5b46532bf2.
* Added battery to platform
* Added control section
* Consistent naming
* Added topics to base and fixed typos
* Added get_topic and get_topic_rate
* Added TOPICS and get_topic
* Added description and launch to generic robot platform
* Added Warthog without Attachments or ROS Parameters
* Contributors: Luis Camero, luis-camero
```
