### PR TITLE
clearpath_simulator: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -144,7 +144,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 0.1.3-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.3-1`

## clearpath_generator_gz

```
* Added Warthog and Dingo to generator
* Added Generic robot components
* Sensor static tf should use robot namespace
* Contributors: Luis Camero, Roni Kreinin
```

## clearpath_gz

```
* Lifted platform to 0.3 m
* Updated links in the warehouse
* Contributors: Luis Camero
```

## clearpath_simulator

- No changes
