### PR TITLE
clearpath_robot: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -119,13 +119,14 @@ repositories:
       version: main
     release:
       packages:
+      - clearpath_diagnostics
       - clearpath_generator_robot
       - clearpath_robot
       - clearpath_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.1.3-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.3-1`

## clearpath_diagnostics

```
* Added S1P2 battery configuration
* Set battery charging status
* Added dingo to battery state control
* Added D100 and D150 to generator and battery node
* Generate lighting node
* Fixed status message firmware version
* J100 -> W200
* Removed shebang
* Use battery model and configuration from clearpath_config
* Removed HMI msg, encode Uint8 instead
* Initial battery control node
* Renamed to battery_state_estimator
  Added to robot generator
* Properties, capacity, voltage
  Create pub/sub only for LiION and SLA
* Added LUT for SLA
* Battery types and configurations
* rolling average
* Initial battery state publisher
* Pass setup path
* Get namespace from robot.yaml for diagnostics launch
  Added diagnostics launch to generator
* Check ros-humble-clearpath-firmware package version
* Add all sensors
* Firmware and sensor diagnostics
* Contributors: Roni Kreinin
```

## clearpath_generator_robot

```
* [clearpath_generator_robot] Disabled depend for now.
* Added D100 and D150 to generator and battery node
* IMU 0 filter for W200
* sevcon_traction dependency
* Generate sevcon traction node
* Generate lighting node
* Launch battery state control
* Renamed to battery_state_estimator
  Added to robot generator
* Get namespace from robot.yaml for diagnostics launch
  Added diagnostics launch to generator
* W200 uROS node
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_robot

```
* Run platform and sensor services as user
* [clearpath_robot] Added udev rule to automatically bring-up CANBUS PCIe card for W200.
* [clearpath_robot] Added can-utils as dep.
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_sensors

```
* Removed 'platform' from default namespace
* Added image proc as container
* Missing comma
* Correct debayer node and add remapping
* Added debayer node
* Removed errant bracket
* add serial number to yaml
* Initial Blackfly addition
* Contributors: Hilary Luo, Luis Camero, Tony Baltovski
```
