### PR TITLE
sevcon_ros: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -206,7 +206,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `1.0.3-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-1`

## sevcon_ros

- No changes

## sevcon_traction

```
* Added boost as dep.
* Revert "Always reset command timer if any command is recieved."
  This reverts commit d992bf072e0a119cba394cf277941ebd0b0b81f4
* Reduced log to debug.
* Changed error log to use hex value.
* Always reset command timer if any command is recieved.
* Fixed typo.
* Added error code log.
* Increased command timeout.
* Contributors: Tony Baltovski
```
