### PR TITLE
husky_observer: 0.0.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -609,11 +609,12 @@ repositories:
       - husky_observer_power_mgmt
       - husky_observer_safety_alarm
       - husky_observer_stack_light
+      - husky_observer_teleop
       - husky_observer_tests
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
-      version: 0.0.14-1
+      version: 0.0.15-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/husky_observer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_observer` to `0.0.15-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/husky_observer.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.14-1`

## husky_observer

- No changes

## husky_observer_bringup

```
* Add dependency on husky_observer_teleop
* Contributors: Chris Iverach-Brereton
```

## husky_observer_diagnostics

```
* Modify diagnostics topic for both AXIS PTZ changes and for using uncompressed images
* Contributors: José Mastrangelo
```

## husky_observer_disk_mgmt

- No changes

## husky_observer_disk_mgmt_msgs

- No changes

## husky_observer_power_mgmt

- No changes

## husky_observer_safety_alarm

- No changes

## husky_observer_stack_light

- No changes

## husky_observer_teleop

```
* Add D-Pad support to control front/rear driving lights
* Contributors: Chris Iverach-Brereton
```

## husky_observer_tests

- No changes
