### PR TITLE
clearpath_msgs: 0.9.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -156,7 +156,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 0.9.5-1
+      version: 0.9.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `0.9.6-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.5-1`

## clearpath_configuration_msgs

- No changes

## clearpath_control_msgs

- No changes

## clearpath_dock_msgs

- No changes

## clearpath_localization_msgs

- No changes

## clearpath_mission_manager_msgs

```
* Add a new service for deleting multiple IDs at once
* Add a new service to import entire mission objects, including their associated tasks & waypoints
* Contributors: Chris Iverach-Brereton
```

## clearpath_mission_scheduler_msgs

- No changes

## clearpath_msgs

- No changes

## clearpath_navigation_msgs

- No changes

## clearpath_platform_msgs

- No changes

## clearpath_safety_msgs

- No changes
