### PR TITLE
cpr_indoornav_husky: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -306,7 +306,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
-      version: 0.3.5-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_husky` to `0.4.0-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-husky.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.5-1`

## cpr_indoornav_husky

```
* Update to work with Otto's 2.26 release
* Add improved support for Husky Observer
* Contributors: Chris Iverach-Brereton, José Mastrangelo
```
