### PR TITLE
clearpath_config: 0.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -54,7 +54,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.2.0-2
+      version: 0.2.1-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.2.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-2`

## clearpath_config

```
* Find packages for meshes / extras urdf (#45 <https://github.com/clearpathrobotics/clearpath_config/issues/45>)
  * Allow meshes visual and extras urdf to be linked using find package functionality
* Contributors: Hilary Luo
```
