### PR TITLE
ptz_action_server: 0.1.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -805,7 +805,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ptz_action_server-release.git
-      version: 0.1.8-1
+      version: 0.1.9-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ptz_action_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ptz_action_server` to `0.1.9-1`:

- upstream repository: https://github.com/clearpathrobotics/ptz_action_server.git
- release repository: https://github.com/clearpath-gbp/ptz_action_server-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.8-1`

## axis_ptz_action_server

```
* Fix a bug in translating the zoom level from the logical to hardware range
* Contributors: Chris Iverach-Brereton
```

## flir_ptu_action_server

- No changes

## ptz_action_server_msgs

- No changes

## simulated_ptz_action_server

- No changes
