### PR TITLE
clearpath_robot: 0.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -126,7 +126,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.2.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## clearpath_diagnostics

```
* Get topic without namespace to address duplicate namespacing
* Contributors: Hilary Luo
```

## clearpath_generator_robot

```
* [clearpath_generator_robot] Re-added sevcon_traction as dependency.
* Contributors: Tony Baltovski
```

## clearpath_robot

- No changes

## clearpath_sensors

- No changes
