### PR TITLE
axis_camera: 0.5.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -26,7 +26,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/axis_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.5.3-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.2-1`

## axis_camera

```
* Use the legacy IR URL by default, falling back to the new one if it's not available; on legacy cameras the new URL returns status 200, even though it doesn't do anything (#81 <https://github.com/ros-drivers/axis_camera/issues/81>)
* Contributors: Chris Iverach-Brereton
```

## axis_description

- No changes

## axis_msgs

- No changes
