### PR TITLE
valence_bms: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -218,6 +218,16 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/um7-release.git
       version: 1.0.1-3
+  valence_bms:
+    release:
+      packages:
+      - valence_bms_driver
+      - valence_bms_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
+      version: 1.0.0-1
+    status: maintained
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `valence_bms` to `1.0.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/valence_bms.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## valence_bms_driver

```
* Initial ros2 import
* Contributors: Hilary Luo
```

## valence_bms_msgs

```
* Initial ros2 import
* Contributors: Hilary Luo
```
