### PR TITLE
clearpath_nav2_demos: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -106,7 +106,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_nav2_demos` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
- release repository: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## clearpath_nav2_demos

```
* Increased inflation radius
* Added W200 configs
* Contributors: Roni Kreinin
```
