### PR TITLE
valence_bms: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -219,6 +219,10 @@ repositories:
       url: https://github.com/ros-drivers-gbp/um7-release.git
       version: 1.0.1-3
   valence_bms:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/valence_bms.git
+      version: main
     release:
       packages:
       - valence_bms_driver
@@ -226,7 +230,11 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
-      version: 1.0.0-1
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/valence_bms.git
+      version: main
     status: maintained
   wireless:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `valence_bms` to `1.0.1-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/valence_bms.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## valence_bms_driver

- No changes

## valence_bms_msgs

```
* [valence_bms_msgs] Fixed package.xml and CMakeLists.txt.
* Contributors: Tony Baltovski
```
