### PR TITLE
valence_bms: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -230,7 +230,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/valence_bms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `valence_bms` to `1.0.2-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/valence_bms.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## valence_bms_driver

- No changes

## valence_bms_msgs

```
* [valence_bms_msgs] Removed lint test.
* Contributors: Tony Baltovski
```
