### PR TITLE
sevcon_ros: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -206,7 +206,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `1.0.5-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.4-1`

## sevcon_ros

- No changes

## sevcon_traction

```
* [sevcon_traction] Suppressed timeout log.
* Contributors: Tony Baltovski
```
