### PR TITLE
clearpath_robot: 0.2.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -126,7 +126,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.2.5-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.4-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* Add valence dependency
* Launch Valence BMS when relevant
* Rename node based on input
* Added rectify and resize
* Float hz parameter
* Contributors: Hilary Luo, Luis Camero, Roni Kreinin
```

## clearpath_robot

- No changes

## clearpath_sensors

```
* Added image_transport_plugins to package.xml
* Added binning parameters
* Recitfy node matches resize
* Added compressed encode and decode launch files
* Fixed theora encoding node
* Add theora encode and decode launch
* Added rectify and resize
* Contributors: Luis Camero
```
