### PR TITLE
clearpath_msgs: 0.9.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -156,7 +156,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 0.9.7-1
+      version: 0.9.8-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `0.9.8-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.7-1`

## clearpath_configuration_msgs

- No changes

## clearpath_control_msgs

- No changes

## clearpath_dock_msgs

```
* Add additional messages for Network of Paths
* Contributors: Chris Iverach-Brereton <mailto:civerachb@clearpathrobotics.com>, Stephen Phillips <mailto:stphillips@clearpathrobotics.com>
```

## clearpath_localization_msgs

```
* Add additional messages for Network of Paths
* Contributors: Chris Iverach-Brereton <mailto:civerachb@clearpathrobotics.com>, Stephen Phillips <mailto:stphillips@clearpathrobotics.com>
```

## clearpath_mission_manager_msgs

```
* Add additional messages for Network of Paths
* Contributors: Chris Iverach-Brereton <mailto:civerachb@clearpathrobotics.com>, Stephen Phillips <mailto:stphillips@clearpathrobotics.com>
```

## clearpath_mission_scheduler_msgs

```
* Add additional messages for Network of Paths
* Contributors: Chris Iverach-Brereton <mailto:civerachb@clearpathrobotics.com>, Stephen Phillips <mailto:stphillips@clearpathrobotics.com>
```

## clearpath_msgs

- No changes

## clearpath_navigation_msgs

```
* Add additional messages for Network of Paths
* Contributors: Chris Iverach-Brereton <mailto:civerachb@clearpathrobotics.com>, Stephen Phillips <mailto:stphillips@clearpathrobotics.com>
```

## clearpath_platform_msgs

- No changes

## clearpath_safety_msgs

```
* remove old commented message
* finalized assisted teleop state message
* change stop field
* add new endline
* change bypass trigger to uint8
* added bypass trigger type to state message
* added assisted teleop messages
* Contributors: José Mastrangelo <mailto:jmastrangelo@clearpathrobotics.com>
```
