### PR TITLE
clearpath_msgs: 0.9.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -156,7 +156,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 0.9.8-1
+      version: 0.9.9-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `0.9.9-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.8-1`

## clearpath_configuration_msgs

- No changes

## clearpath_control_msgs

- No changes

## clearpath_dock_msgs

```
* Message updates for onav-0.12 (#34 <https://github.com/clearpathrobotics/clearpath_msgs/issues/34>)
  * Add the size_exceeded field to NetworkMapState
  * Mod: Update dock messages for new 0.12 docking APIs
  * Mod: Add new autonomy API types to AutonomyStatus.msg
  * Mod: Use float64 version of Vector2D for returning path recording lat-lons
  * Mod: Add header field to RunNetworkGoToPlanner.action feedback
  ---------
  Co-authored-by: Chris Iverach-Brereton <mailto:civerachb@clearpathrobotics.com>
* Contributors: stephen-cpr
```

## clearpath_localization_msgs

- No changes

## clearpath_mission_manager_msgs

```
* Message updates for onav-0.12 (#34 <https://github.com/clearpathrobotics/clearpath_msgs/issues/34>)
  * Add the size_exceeded field to NetworkMapState
  * Mod: Update dock messages for new 0.12 docking APIs
  * Mod: Add new autonomy API types to AutonomyStatus.msg
  * Mod: Use float64 version of Vector2D for returning path recording lat-lons
  * Mod: Add header field to RunNetworkGoToPlanner.action feedback
  ---------
  Co-authored-by: Chris Iverach-Brereton <mailto:civerachb@clearpathrobotics.com>
* Contributors: stephen-cpr
```

## clearpath_mission_scheduler_msgs

- No changes

## clearpath_msgs

- No changes

## clearpath_navigation_msgs

```
* Message updates for onav-0.12 (#34 <https://github.com/clearpathrobotics/clearpath_msgs/issues/34>)
  * Add the size_exceeded field to NetworkMapState
  * Mod: Update dock messages for new 0.12 docking APIs
  * Mod: Add new autonomy API types to AutonomyStatus.msg
  * Mod: Use float64 version of Vector2D for returning path recording lat-lons
  * Mod: Add header field to RunNetworkGoToPlanner.action feedback
  ---------
  Co-authored-by: Chris Iverach-Brereton <mailto:civerachb@clearpathrobotics.com>
* Contributors: stephen-cpr
```

## clearpath_platform_msgs

- No changes

## clearpath_safety_msgs

- No changes
