### PR TITLE
cpr_onav_description: 0.1.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -384,7 +384,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_onav_description-release.git
-      version: 0.1.10-1
+      version: 0.1.11-1
     source:
       type: git
       url: https://github.com/cpr-application/cpr_onav_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_onav_description` to `0.1.11-1`:

- upstream repository: https://github.com/cpr-application/cpr_onav_description.git
- release repository: https://github.com/clearpath-gbp/cpr_onav_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.10-1`

## cpr_onav_description

```
* Added teleop urdf functionality
* Add the top-down SVGs for Husky Observer
* Contributors: Chris Iverach-Brereton, José Mastrangelo
```
