### PR TITLE
husky_observer: 0.0.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -614,7 +614,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
-      version: 0.0.17-1
+      version: 0.0.18-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/husky_observer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_observer` to `0.0.18-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/husky_observer.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/husky_observer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.17-1`

## husky_observer

- No changes

## husky_observer_bringup

- No changes

## husky_observer_diagnostics

- No changes

## husky_observer_disk_mgmt

- No changes

## husky_observer_disk_mgmt_msgs

- No changes

## husky_observer_power_mgmt

- No changes

## husky_observer_safety_alarm

```
* Subscribe to cmd_vel_out instead of cmd_vel. Update subscriber function to use TwistStamped instead of Twist
* Contributors: Chris Iverach-Brereton
```

## husky_observer_stack_light

- No changes

## husky_observer_teleop

- No changes

## husky_observer_tests

- No changes
