### PR TITLE
ridgeback_robot: 0.4.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -931,7 +931,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_robot-release.git
-      version: 0.4.3-1
+      version: 0.4.3-2
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_robot` to `0.4.3-2`:

- upstream repository: https://github.com/ridgeback/ridgeback_robot.git
- release repository: https://github.com/clearpath-gbp/ridgeback_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.3-1`

## ridgeback_base

- No changes

## ridgeback_bringup

```
* Add microstrain_inertial_driver to support current Microstrain IMU models (#37 <https://github.com/ridgeback/ridgeback_robot/issues/37>)
  * Add microstrain_inertial_driver for supporting current Microstrain IMU models.
  * Remove accidental copy
  * Clearer comments for RIDGEBACK_IMU_MICROSTRAIN.
* Contributors: Joey Yang
```

## ridgeback_robot

- No changes
