### PR TITLE
warthog: 0.1.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1062,7 +1062,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.1.8-1
+      version: 0.1.9-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.9-1`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.8-1`

## warthog_control

```
* Mod: Set 'publish_cmd' param to true in warthog_control/config
  - With this change the diff drive controller will output the final cmd_vel to /warthog_velocity_controller/cmd_vel_out after any filters are applied (e.g., speed/acceleration limits)
* Contributors: Stephen Phillips
```

## warthog_description

```
* Updated meshes to add antennas and E-stop buttons
* Remove robotNamespace in .gazebo file
* Contributors: Antonio Manuel Burgueño Romero, Luis Camero
```

## warthog_msgs

- No changes
