### PR TITLE
clearpath_robot: 0.2.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -127,7 +127,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.2.7-1
+      version: 0.2.8-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.2.8-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.7-1`

## clearpath_diagnostics

```
* Even more lint errors
* More linting changes
* Fixed linting errors
* Contributors: Luis Camero
```

## clearpath_generator_robot

```
* Lint error in test
* Workspace install paths
* Ignore error from deleting clearpath temp folder
* More linting changes
* Fixed linting errors
* Added pytest to check config
* Fixed linter errors
* Contributors: Luis Camero
```

## clearpath_robot

```
* Ensure that the network interfaces are active before clearpath_robot service starts - required for FastDDS
* Contributors: Hilary Luo
```

## clearpath_sensors

```
* Map points to API
* Fixed linting errors
* Renamed realsense node to intel_realsense
* Remapped realsense topics
* Contributors: Luis Camero
```
