### PR TITLE
clearpath_robot: 0.2.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -127,7 +127,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.2.8-1
+      version: 0.2.9-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.2.9-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.8-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* Fix tf_static for realsense and microstrain
* Contributors: Hilary Luo
```

## clearpath_robot

- No changes

## clearpath_sensors

```
* Fix tf_static for realsense and microstrain
* Contributors: Hilary Luo
```
