### PR TITLE
nmea_navsat_driver: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -203,11 +203,20 @@ repositories:
       url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
       version: 1.0.0-1
   nmea_navsat_driver:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/nmea_navsat_driver.git
+      version: ros2
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
-      version: 2.0.0-1
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/nmea_navsat_driver.git
+      version: ros2
+    status: maintained
   serial:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `2.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/nmea_navsat_driver.git
- release repository: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## nmea_navsat_driver

```
* Changed tf_transformations to python3-transforms3d.
* Sentence field must be of type str (#173 <https://github.com/clearpathrobotics/nmea_navsat_driver/issues/173>)
  In nmea_topic_serial_reader, sentence field is a bytes object and should be a str object.
  Fixes: https://github.com/ros-drivers/nmea_navsat_driver/issues/172
  Co-authored-by: Fletcher Thompson <mailto:fletho@dtu.dk>
* Contributors: FletcherFT, Tony Baltovski
```
