### PR TITLE
axis_camera: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6,6 +6,25 @@ release_platforms:
   ubuntu:
   - jammy
 repositories:
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: humble-devel
+    release:
+      packages:
+      - axis_camera
+      - axis_description
+      - axis_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/axis_camera-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: humble-devel
+    status: developed
   camera_info_manager_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## axis_camera

```
* Initial release for ROS 2
* Contributors: Chris Iverach-Brereton, Mike Hosmar
```

## axis_description

```
* Initial release for ROS 2
* Contributors: Chris Iverach-Brereton, Mike Hosmar
```

## axis_msgs

```
* Initial release for ROS 2
* Contributors: Chris Iverach-Brereton, Mike Hosmar
```
