### PR TITLE
cpr_indoornav_husky: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -306,7 +306,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_husky` to `0.4.2-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-husky.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.1-1`

## cpr_indoornav_husky

```
* Use galactic by default
* Modify the husky power monitor node to subscribe to multiple inputs to more gracefully handle lithium battery upgrades
* Contributors: Chris Iverach-Brereton
```
