### PR TITLE
cpr_indoornav_ridgeback: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -336,7 +336,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_ridgeback-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_ridgeback` to `0.4.2-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-ridgeback.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_ridgeback-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.1-1`

## cpr_indoornav_ridgeback

```
* Use galactic by default
* Contributors: Chris Iverach-Brereton
```
