### PR TITLE
cpr_indoornav_tests: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -351,7 +351,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_tests-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-tests.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_tests` to `0.3.3-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-tests.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_tests-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.2-1`

## cpr_indoornav_tests

```
* Use galactic by default
* Improve support for different IMUs
* Contributors: Chris Iverach-Brereton
```
