### PR TITLE
cpr_onav_description: 0.1.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -384,7 +384,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_onav_description-release.git
-      version: 0.1.11-1
+      version: 0.1.12-1
     source:
       type: git
       url: https://github.com/cpr-application/cpr_onav_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_onav_description` to `0.1.12-1`:

- upstream repository: https://github.com/cpr-application/cpr_onav_description.git
- release repository: https://github.com/clearpath-gbp/cpr_onav_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.11-1`

## cpr_onav_description

```
* Fix the Axis camera prefixes so we can more-easily identify the sensor frames
* Changed prefix for ptz cameras
* Added antenna links to urdf
* Change axis_ptz_num to axis_q62_num for Q62 specific entries
* Use the axis_description package for the camera URDFs, add axis dome camera meshes
* Add ptz camera links to urdf
* Added color of xvn unit
* Fix axis of xvn stl file
* Added xvn stl to model
* Revert fender fix. use position relative to base_link
* Correct unless close
* Add dependency on jackal fenders
* Fix rear laser xyz, rpy
* Added xvn link to urdf
* Contributors: Chris Iverach-Brereton, José Mastrangelo
```
