### PR TITLE
video_recorder: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1043,7 +1043,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/video_recorder-release.git
-      version: 0.0.10-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/video_recorder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_recorder` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/video_recorder.git
- release repository: https://github.com/clearpath-gbp/video_recorder-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.10-1`

## audio_recorder

```
* Add a header to the result objects for all actions (#6 <https://github.com/clearpathrobotics/video_recorder/issues/6>)
* Contributors: Chris Iverach-Brereton
```

## audio_recorder_msgs

```
* Add a header to the result objects for all actions (#6 <https://github.com/clearpathrobotics/video_recorder/issues/6>)
* Contributors: Chris Iverach-Brereton
```

## video_recorder

```
* Add a header to the result objects for all actions (#6 <https://github.com/clearpathrobotics/video_recorder/issues/6>)
* Contributors: Chris Iverach-Brereton
```

## video_recorder_msgs

```
* Add a header to the result objects for all actions (#6 <https://github.com/clearpathrobotics/video_recorder/issues/6>)
* Contributors: Chris Iverach-Brereton
```
