### PR TITLE
dingo_robot: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -490,7 +490,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_robot-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_robot` to `0.3.2-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_robot.git
- release repository: https://github.com/clearpath-gbp/dingo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-1`

## dingo_base

- No changes

## dingo_bringup

```
* Updated Microstrain config
* Updated realsense tf_prefix in nodelet launch to match urdf
* Contributors: Hilary Luo, Luis Camero
```

## dingo_robot

- No changes
