### PR TITLE
axis_camera: 2.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -19,7 +19,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-drivers/axis_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `2.0.1-2`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## axis_camera

```
* Remove the unused Axis.msg (all relevant information is now published in independent topics). Fix action imports in axis_ptz
* Contributors: Chris Iverach-Brereton
```

## axis_description

- No changes

## axis_msgs

```
* Remove the unused Axis.msg (all relevant information is now published in independent topics). Fix action imports in axis_ptz
* Contributors: Chris Iverach-Brereton
```
