### PR TITLE
cpr_indoornav_base: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -276,7 +276,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_base-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr_indoornav_base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_base` to `0.4.2-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-base.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_base-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.1-1`

## cpr_indoornav_base

```
* Remove dependency on the old clearpath_api package, install the new api packages
* Contributors: Chris Iverach-Brereton
```
