### PR TITLE
cpr_indoornav_dingo: 0.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -291,7 +291,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_dingo-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_dingo` to `0.4.3-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-dingo.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_dingo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.2-1`

## cpr_indoornav_dingo

```
* Use the new ROS 2 API packages
* Contributors: Chris Iverach-Brereton
```
