### PR TITLE
clearpath_msgs: 0.10.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -143,10 +143,12 @@ repositories:
       version: noetic-devel
     release:
       packages:
+      - clearpath_camera_msgs
       - clearpath_configuration_msgs
       - clearpath_control_msgs
       - clearpath_dock_msgs
       - clearpath_localization_msgs
+      - clearpath_logger_msgs
       - clearpath_mission_manager_msgs
       - clearpath_mission_scheduler_msgs
       - clearpath_msgs
@@ -156,7 +158,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 0.9.9-1
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `0.10.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.9-1`

## clearpath_camera_msgs

```
* Changes
* Merge pull request #46 <https://github.com/clearpathrobotics/clearpath_msgs/issues/46> from clearpathrobotics/0.13/features
  0.13/features
* fix endline
* Merge remote-tracking branch 'refs/remotes/origin/poi' into 0.13/features
* added zoom to inspect poi action
* create new camera msg package with InspectPOI action
* Contributors: Chris Iverach-Brereton, José Mastrangelo, Stephen Phillips, jmastrangelo-cpr
* Initial release of clearpath_camera_msgs
* Added zoom to inspect POI action
* Create new camera msg package with InspectPOI action
* Contributors: José Mastrangelo, Stephen Phillips
```

## clearpath_configuration_msgs

- No changes

## clearpath_control_msgs

- No changes

## clearpath_dock_msgs

- No changes

## clearpath_localization_msgs

```
* Add: XvnStatus.msg for when XVN is used as localization sensor
  - Provides information on current position/heading + confidence as well as other XVN feature statuses (e.g., IMU bias convergence)
* Contributors: Stephen Phillips
```

## clearpath_logger_msgs

```
* Merge pull request #46 <https://github.com/clearpathrobotics/clearpath_msgs/issues/46> from clearpathrobotics/0.13/features
  0.13/features
* Merge remote-tracking branch 'refs/remotes/origin/mission-logger' into 0.13/features
* Docs
* mission_uuid -> name in StartRecording
* EventLog mission_uuid -> name
* Add MIME types to media events
* Remove quotation marks around string constants; they are not required
* Add error event logging, add a custom json field to the master event log
* Add the custom json data to the stop_recording service
* Change the heading units
* Add the EventLogs message
* Add an additional flag to expunge the master record if desired
* Add the service to delete logs
* Add a flag to indicate if media files are missing from recording archives
* Add the auto_telemetry tag
* Remove an unnecessary dependency
* Fix the all-logs service to return an array
* Fix constants
* Add additional services, add fields to event-recorder services
* Add the download-log service
* TAG_POSITION -> TAG_LOCATION, add frame_id to custom events
* Add additional services
* Add the custom event service
* Add initial event-recording services
* Add first-draft Event, EventLog messages
* Fill in the skeleton for the new messages package
* Contributors: Chris Iverach-Brereton, Stephen Phillips, jmastrangelo-cpr
```

## clearpath_mission_manager_msgs

```
* Merge pull request #46 <https://github.com/clearpathrobotics/clearpath_msgs/issues/46> from clearpathrobotics/0.13/features
  0.13/features
* Merge remote-tracking branch 'refs/remotes/origin/poi' into 0.13/features
* Add enable_heading to POI create/edit messages
* Add new Mission Manager messages & services related to POI creation/deletion/modification (#42 <https://github.com/clearpathrobotics/clearpath_msgs/issues/42>)
  * Add tag constants for PTZ and GoTo labels. Add initial services for creating & updating POIs, creating Waypoints from POIs
  * Add accessors for the points of interest
  * Add the clone point of interest service
  * Add the new_name field to the POI clone service
  * Add service for adding/removing tags
* Merge pull request #41 <https://github.com/clearpathrobotics/clearpath_msgs/issues/41> from clearpathrobotics/ONAV-2371
  added point of interest message
* added point of interest message
* Contributors: Chris Iverach-Brereton, José Mastrangelo, Stephen Phillips, jmastrangelo-cpr
```

## clearpath_mission_scheduler_msgs

```
* Revert changes to support scheduling network of paths missions. This feature will be reintroduced in a future release (#40 <https://github.com/clearpathrobotics/clearpath_msgs/issues/40>)
* Contributors: Chris Iverach-Brereton
```

## clearpath_msgs

```
* Merge pull request #46 <https://github.com/clearpathrobotics/clearpath_msgs/issues/46> from clearpathrobotics/0.13/features
  0.13/features
* Merge remote-tracking branch 'refs/remotes/origin/poi' into 0.13/features
* create new camera msg package with InspectPOI action
* Contributors: José Mastrangelo, Stephen Phillips, jmastrangelo-cpr
```

## clearpath_navigation_msgs

```
* Merge pull request #46 <https://github.com/clearpathrobotics/clearpath_msgs/issues/46> from clearpathrobotics/0.13/features
  0.13/features
* fix endline
* 0.13/features: Changed the ptz constant for poi's
* Merge remote-tracking branch 'refs/remotes/origin/poi' into 0.13/features
* create new camera msg package with InspectPOI action
* added InspectPOI action
* consistency fix from network to map
* Merge branch 'poi' of github.com:clearpathrobotics/clearpath_msgs into poi
* Remove quotation marks around string constants; they are not needed
* added network goto poi values
* added a boolean enable_heading flag (#44 <https://github.com/clearpathrobotics/clearpath_msgs/issues/44>)
* Add new Mission Manager messages & services related to POI creation/deletion/modification (#42 <https://github.com/clearpathrobotics/clearpath_msgs/issues/42>)
  * Add tag constants for PTZ and GoTo labels. Add initial services for creating & updating POIs, creating Waypoints from POIs
  * Add accessors for the points of interest
  * Add the clone point of interest service
  * Add the new_name field to the POI clone service
  * Add service for adding/removing tags
* Merge pull request #41 <https://github.com/clearpathrobotics/clearpath_msgs/issues/41> from clearpathrobotics/ONAV-2371
  added point of interest message
* added newline
* added point of interest message
* Add: Publish the robot's current high-level plan as part of NetworkGotoFeedback (#36 <https://github.com/clearpathrobotics/clearpath_msgs/issues/36>)
* Merge pull request #35 <https://github.com/clearpathrobotics/clearpath_msgs/issues/35> from clearpathrobotics/mod/onav_msg_updates
  ONav message type changes
* Add: Boolean '.paused' field to AutonomyStatus
* Mod: Add result message + rename feedback.state to feedback.message for waypoint mission types
* Contributors: Chris Iverach-Brereton, Drew O'Brien, José Mastrangelo, Stephen Phillips, Tony Baltovski, jmastrangelo-cpr, stephen-cpr
```

## clearpath_platform_msgs

- No changes

## clearpath_safety_msgs

```
* refactor (#39 <https://github.com/clearpathrobotics/clearpath_msgs/issues/39>)
* remove bypass service. no longer needed as we will be using std_srvs/SetBool (#38 <https://github.com/clearpathrobotics/clearpath_msgs/issues/38>)
* added error state to assisted teleop (#37 <https://github.com/clearpathrobotics/clearpath_msgs/issues/37>)
* Contributors: jmastrangelo-cpr
```
