### PR TITLE
clearpath_common: 0.2.10-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -69,7 +69,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.2.9-1
+      version: 0.2.10-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `0.2.10-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.9-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform

- No changes

## clearpath_platform_description

```
* Topics of simulated onboard sensors
* Missing important remapping to mirror hardware topics
* Contributors: Luis Camero, Steve Macenski
```

## clearpath_sensors_description

```
* Realsense adds optical links when in simulator
* Updated topic names to match gazebo message types
* Added topic to gazebo plugins
* Contributors: Luis Camero
```
