### PR TITLE
puma_motor_driver: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -253,6 +253,25 @@ repositories:
       url: https://github.com/clearpathrobotics/ptz_action_server.git
       version: ros2
     status: developed
+  puma_motor_driver:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/puma_motor_driver.git
+      version: foxy-devel
+    release:
+      packages:
+      - clearpath_socketcan_interface
+      - puma_motor_driver
+      - puma_motor_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/puma_motor_driver.git
+      version: foxy-devel
+    status: maintained
   serial:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `puma_motor_driver` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/puma_motor_driver.git
- release repository: https://github.com/clearpath-gbp/puma_motor_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_socketcan_interface

```
* Deleted the CHANGELOG
* Version match to puma_motor_driver
* Renamed socketcan_interface to clearpath_socket_interface
* Contributors: Luis Camero
```

## puma_motor_driver

```
* Removed info logging
* Restored commandSpeed
* Spacing fixes
* Updated topics to match API
* Renamed socketcan_interface to clearpath_socket_interface
* Topic in node namespace
* Renamed robot to multi_puma_node
* Fixed include
* Add launch files and configuration files
* Add new multi puma node
* Modified header to include new functions
* Removed launch files
* Removed split multi control node
* Add retrieval functions with received checks
* properly using Boost shared library now
* added -fPIC build option
* exported header files
* built in ROS Foxy without errors
* Contributors: Joep Tool, Luis Camero, joe28965
```

## puma_motor_msgs

```
* updated msgs to foxy
* Contributors: joe28965
```
