### PR TITLE
clearpath_robot: 0.2.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -156,7 +156,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.2.12-1
+      version: 0.2.13-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.2.13-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.12-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

```
* Fixed bug in microstrain param
* Fixed remapping to allow for compressed vizualization
* Contributors: Luis Camero
```
