### PR TITLE
clearpath_mecanum_drive_controller: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -109,6 +109,13 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_desktop.git
       version: main
     status: developed
+  clearpath_mecanum_drive_controller:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_mecanum_drive_controller-release.git
+      version: 0.1.0-1
+    status: maintained
   clearpath_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_mecanum_drive_controller` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_mecanum_drive_controller.git
- release repository: https://github.com/clearpath-gbp/clearpath_mecanum_drive_controller-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_mecanum_drive_controller

```
* Add dependency on hardware interface testing
* Fixed tests
* Renamed to clearpath_mecanum_drive_controller
* Contributors: Luis Camero
```
