### PR TITLE
cpr_indoornav_navigation: 0.0.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -341,7 +341,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_indoornav_navigation-release.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr-indoornav-navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_indoornav_navigation` to `0.0.1-2`:

- upstream repository: https://github.com/clearpathrobotics/cpr-indoornav-navigation.git
- release repository: https://github.com/clearpath-gbp/cpr_indoornav_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-1`

## cpr_indoornav_navigation

```
* Initial release
* Contributors: Chris Iverach-Brereton
```

## cpr_indoornav_navigation_msgs

```
* Initial release
* Contributors: Chris Iverach-Brereton
```
