### PR TITLE
wireless: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -339,7 +339,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## wireless_msgs

- No changes

## wireless_watcher

```
* Set NaN when empty BitRate/Frequency
* Add try-catch to BitRate and Frequency field
* Contributors: Luis Camero
```
