### PR TITLE
nmea_navsat_driver: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -228,6 +228,12 @@ repositories:
         release: release/humble/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
       version: 1.0.0-1
+  nmea_navsat_driver:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
+      version: 2.0.3-1
   ptz_action_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `2.0.3-1`:

- upstream repository: https://github.com/clearpathrobotics/nmea_navsat_driver.git
- release repository: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## nmea_navsat_driver

```
* Merge pull request #1 <https://github.com/clearpathrobotics/nmea_navsat_driver/issues/1> from clearpathrobotics/lcamero/tf_depend
  Add exec_depend for tf_transformations
* Add exec_depend for tf_transformations
* Contributors: Luis Camero, Tony Baltovski
```
