### PR TITLE
clearpath_robot: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -165,7 +165,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.2.15-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.15-1`

## clearpath_diagnostics

```
* R100 Initial Battry
* Contributors: Luis Camero, luis-camero
```

## clearpath_generator_robot

```
* Only add manipulator.launch if manipulator added
* Add Ridgeback to generator
* Added dependency to puma_motor_driver
* Added puma node to generated platform launch
* Added manipulators to launch generator
* Contributors: Luis Camero, luis-camero
```

## clearpath_robot

```
* Enable vcan service when installed
* Add dependency socat
* Headers to bash scripts
* Add R100 to Puma enabled
* Use root as user
* Add vcan service
* Added vcan script
* Added SRDF generation to robot service
* Removed incorrect dependency
* Added manipulators dependencies and service
* Contributors: Luis Camero, luis-camero
```

## clearpath_sensors

```
* Disable all tools in default microstrain config
* Update remappings on image_resize republisher
* Add relay to have a camera info topic
* Contributors: Luis Camero, luis-camero
```
