### PR TITLE
clearpath_robot: 0.3.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -165,7 +165,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `0.3.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

- No changes

## clearpath_robot

```
* [clearpath_robot] Added script to grab diagnostic logs for troubleshooting.
* Contributors: Luis Camero, Tony Baltovski
```

## clearpath_sensors

```
* Add OAKD camera
* Add phidget spatial config and launch files
* Contributors: Luis Camero, Tony Baltovski
```
