### PR TITLE
puma_motor_driver: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -266,7 +266,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/puma_motor_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `puma_motor_driver` to `1.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/puma_motor_driver.git
- release repository: https://github.com/clearpath-gbp/puma_motor_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## clearpath_socketcan_interface

```
* Add 1ms wait
* Added LICENSE per package.
* Fix linting issues
* Contributors: Luis Camero, Tony Baltovski
```

## puma_motor_driver

```
* Added LICENSE per package.
* Contributors: Tony Baltovski
```

## puma_motor_msgs

```
* Added LICENSE per package.
* Contributors: Tony Baltovski
```
