### PR TITLE
axis_camera: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -19,7 +19,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
-      version: 2.0.2-2
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/axis_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `2.0.3-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-2`

## axis_camera

```
* Add/cmd vel topic (#90 <https://github.com/ros-drivers/axis_camera/issues/90>)
  * added cmd/velocity topic for continuous velocity control
* Contributors: Jose Mastrangelo
```

## axis_description

- No changes

## axis_msgs

- No changes
