### PR TITLE
clearpath_msgs: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6,6 +6,24 @@ release_platforms:
   ubuntu:
   - noble
 repositories:
+  clearpath_msgs:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: humble
+    release:
+      packages:
+      - clearpath_msgs
+      - clearpath_platform_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: humble
+    status: maintained
   simple_term_menu_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_msgs

- No changes

## clearpath_platform_msgs

- No changes
