### PR TITLE
clearpath_ros2_socketcan_interface: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -171,6 +171,21 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_robot.git
       version: main
     status: developed
+  clearpath_ros2_socketcan_interface:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
+      version: humble
+    status: maintained
   clearpath_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_ros2_socketcan_interface` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
- release repository: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_ros2_socketcan_interface

```
* Change CI to Humble.
* Added README.
* Disabled copyright tests.
* Fixed linting.
* Added CI
* Added issue templates.
* Added codeowners.
* Updated package.xml
* Merge pull request #2 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/2> from clearpathrobotics/rkreinin/callback
  Constructor with callback
* Tx queue and wall timer
* Constructor with callback
  License
* Merge pull request #1 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/1> from clearpathrobotics/cib/jazzy-fixes
  Small code styling to make default tests pass
* Small code styling to make default tests pass
* Add delay before publishing messages
* Initial add of clearpath_ros2_socketcan_interface
* Initial commit
* Contributors: Chris Iverach-Brereton, Luis Camero, Roni Kreinin, Tony Baltovski, luis-camero
```
