### PR TITLE
clearpath_ros2_socketcan_interface: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -24,6 +24,21 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_msgs.git
       version: humble
     status: maintained
+  clearpath_ros2_socketcan_interface:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
+      version: jazzy
+    status: maintained
   simple_term_menu_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_ros2_socketcan_interface` to `2.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
- release repository: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_ros2_socketcan_interface

```
* Added README.
* Disabled copyright tests.
* Fixed linting.
* Added CI
* Added issue templates.
* Added codeowners.
* Updated package.xml
* Tx queue and wall timer
* Constructor with callback
* Small code styling to make default tests pass
* Add delay before publishing messages
* Initial add of clearpath_ros2_socketcan_interface
* Initial commit
* Contributors: Chris Iverach-Brereton, Luis Camero, Roni Kreinin, Tony Baltovski
```
