### PR TITLE
clearpath_config: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -86,7 +86,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.3.4-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.4-1`

## clearpath_config

```
* Add default vcan ROS interfaces based on platform
* Add support for Axis cameras (#90 <https://github.com/clearpathrobotics/clearpath_config/issues/90>)
  * Add the initial AxisCamera class with all ROS parameters defined in axis_camera's launch files & nodes
  * Add the AxisCamera class to the sensors generator
  * Add the serial to the axis camera's template
  * Add serial to the template keys too
  * Add serial getter/setter. Use empty string as default serial
  * Refactoring, set the property to the value for the template
  * frame_width -> width, frame_height -> height
  * Rename setter
  * Make the scales & offsets floats by default
  * Add the TF prefix parameter
  * Add the camera_info_url parameter
  * camera_num -> camera
  * Note that the serial isn't used, fix the name of the PTZ teleop parameter
  * Add the remaining camera topics to the Topics object
  * image_raw -> image
  * Add axis_camera sample
* Remove empty line at EoF
* Add ur_arm
* Add header
* rx and tx topics for can bridge
* Initial can_bridges add
* Add a sample for each sensor
* Contributors: Chris Iverach-Brereton, Luis Camero
```
