### PR TITLE
clearpath_common: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -65,13 +65,12 @@ repositories:
       - clearpath_manipulators
       - clearpath_manipulators_description
       - clearpath_mounts_description
-      - clearpath_platform
       - clearpath_platform_description
       - clearpath_sensors_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.3.4-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.4-1`

## clearpath_common

```
* Added minimum version.
* Remove all references to clearpath_platform
* Move platform.launch.py to clearpath_common metapackage
* Contributors: Luis Camero, Tony Baltovski
```

## clearpath_control

```
* Fix controller names and kinematics (#109 <https://github.com/clearpathrobotics/clearpath_common/issues/109>)
* Contributors: luis-camero
```

## clearpath_customization

- No changes

## clearpath_description

```
* Added minimum version.
* Contributors: Tony Baltovski
```

## clearpath_generator_common

```
* Added minimum version.
* Remove all references to clearpath_platform
* Add support for Axis cameras (#113 <https://github.com/clearpathrobotics/clearpath_common/issues/113>)
  * Add axis camera URDFs & meshes
  * Fix the path for the meshes
  * Add the AxisCameraDescription class
  * Remove the axis_camera files, add a dependency on axis_description. Add a new meta-macro that uses the camera type
  * Use the device_type to set the model for the new description macro
  * Add the update_rate to the URDF
  * Add default topic for the URDF
  * Remove the update_rate parameter; it's not supported by axis_camera
  * Add the update_rate parameter back to the meta macro, but don't pass it
  * Add the axis camera URDFs & STLs from axis_description, use the local copies instead of having an external dependency
  * Add RGBA values for the "black" material, rename it to avoid conflicting with any other material definitions
* Add UR arm (#110 <https://github.com/clearpathrobotics/clearpath_common/issues/110>)
* VCAN Rework (#112 <https://github.com/clearpathrobotics/clearpath_common/issues/112>)
  * VCan service script generator
  * Use formatted strings to shorten line length and expose variables
* Add test exception for Zed (#100 <https://github.com/clearpathrobotics/clearpath_common/issues/100>)
* Contributors: Chris Iverach-Brereton, Luis Camero, Tony Baltovski, luis-camero
```

## clearpath_manipulators

```
* Added minimum version.
* Fix controller names and kinematics (#109 <https://github.com/clearpathrobotics/clearpath_common/issues/109>)
* Contributors: Tony Baltovski, luis-camero
```

## clearpath_manipulators_description

```
* Add UR arm (#110 <https://github.com/clearpathrobotics/clearpath_common/issues/110>)
* Contributors: luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* [clearpath_platform_description] Fixed gazebo_controllers param file. (#107 <https://github.com/clearpathrobotics/clearpath_common/issues/107>)
* Remove all references to clearpath_platform
* Add collision tags for MoveIt to avoid these objects (#108 <https://github.com/clearpathrobotics/clearpath_common/issues/108>)
* [clearpath_platform_description] Fixed gazebo_controllers param file. (#107 <https://github.com/clearpathrobotics/clearpath_common/issues/107>)
* Contributors: Luis Camero, Tony Baltovski, luis-camero
```

## clearpath_sensors_description

```
* Add support for Axis cameras (#113 <https://github.com/clearpathrobotics/clearpath_common/issues/113>)
  * Add axis camera URDFs & meshes
  * Fix the path for the meshes
  * Add the AxisCameraDescription class
  * Remove the axis_camera files, add a dependency on axis_description. Add a new meta-macro that uses the camera type
  * Use the device_type to set the model for the new description macro
  * Add the update_rate to the URDF
  * Add default topic for the URDF
  * Remove the update_rate parameter; it's not supported by axis_camera
  * Add the update_rate parameter back to the meta macro, but don't pass it
  * Add the axis camera URDFs & STLs from axis_description, use the local copies instead of having an external dependency
  * Add RGBA values for the "black" material, rename it to avoid conflicting with any other material definitions
* Contributors: Chris Iverach-Brereton
```
