### PR TITLE
clearpath_simulator: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -199,7 +199,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 0.3.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## clearpath_generator_gz

```
* Added minimum version.
* Contributors: Tony Baltovski
```

## clearpath_gz

```
* Added minimum version.
* Play sim automatically (#52 <https://github.com/clearpathrobotics/clearpath_simulator/issues/52>)
  * Play sim automatically
  * Accept auto_start as a launch configuration to support previous behavior although default is true
* Contributors: Hilary Luo, Tony Baltovski
```

## clearpath_simulator

```
* Added minimum version.
* Contributors: Tony Baltovski
```
