### PR TITLE
clearpath_nav2_demos: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -145,7 +145,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
-      version: 0.2.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_nav2_demos` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
- release repository: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.0-1`

## clearpath_nav2_demos

```
* Added minimum version.
* Add config files for dingo, ridgeback. Waiting for confirmation that the acceleration limits & max angular velocities are correct
* Copy velocity & acceleration limits from clearpath_control
* Contributors: Tony Baltovski, Chris Iverach-Brereton
```
