### PR TITLE
clearpath_ros2_socketcan_interface: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -182,7 +182,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_ros2_socketcan_interface` to `1.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
- release repository: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## clearpath_ros2_socketcan_interface

```
* Add our own launch files that allow us to change namespaces
* Contributors: Luis Camero
```
