### PR TITLE
serial: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -271,11 +271,20 @@ repositories:
       version: ros2
     status: developed
   serial:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/serial-ros2.git
+      version: master
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/serial-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/serial-ros2.git
+      version: master
+    status: maintained
   sevcon_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `serial` to `2.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/serial-ros2.git
- release repository: https://github.com/clearpath-gbp/serial-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## serial

```
* Add cmake flags and use target include
* Contributors: Luis Camero
```
