### PR TITLE
serial: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -49,7 +49,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/serial-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/serial-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `serial` to `2.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/serial-ros2.git
- release repository: https://github.com/clearpath-gbp/serial-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## serial

```
* Add cmake flags and use target include
* Contributors: Luis Camero
```
