### PR TITLE
ewellix_lift: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -207,6 +207,27 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_simulator.git
       version: main
     status: developed
+  ewellix_lift:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/ewellix_lift.git
+      version: humble
+    release:
+      packages:
+      - ewellix_description
+      - ewellix_driver
+      - ewellix_examples
+      - ewellix_interfaces
+      - ewellix_moveit_config
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/ewellix_lift-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/ewellix_lift.git
+      version: humble
+    status: developed
   flir_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ewellix_lift` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/ewellix_lift.git
- release repository: https://github.com/clearpath-gbp/ewellix_lift-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ewellix_description

```
* Add launch parameter to modify lift description
* Add friction and initialize lift extended
* Add all meshes and description configs
* Updated URDF and MoveIt for mimic joint
* Add gazebo tag
* Add gazebo tag
* Use mimic joint
* Pass origin instead of block
* Reset package versions to 0.0.0
* remove empty dependency
* Add sample URDF
* Increase tolerance
* Fix position of mounting link
* Add 2.25cm offset to upper tower
* Initial add of Ewellix driver
* Initial description package
* Contributors: Luis Camero
```

## ewellix_driver

```
* Removed logging
* Remove INFO logs
* Switch to stop before execute motion
* Add recovery
* Add Out and In execute functions
* Catch overcurrent
* Remove INFO logs
* Switch to stop before execute motion
* Add recovery
* Add Out and In execute functions
* Catch overcurrent
* Duplicate joint count to account for mimic joints
* Use ewellix_interfaces instead of std
* Add new interfaces
* Update default port
* Reset package versions to 0.0.0
* Add custom messages
* Fix parameters
* Initialize vectors in each line
* Use this to reference member methods
* Remove unused source file
* Refactor Ewellix node to use asynchronous thread
* Remove commented out code
* Use CycleData2 and asyncThread
* Use classes instead of structs
* Update hardware_interface to use DataCycle2
* Use DataCycle2 in node
* Add DataCycle2
* Initial add of Ewellix driver
* Contributors: Luis Camero
```

## ewellix_examples

```
* Use GroupAction instead of PythonExpression conditions
* Set default velocity scaling factor to 1.0
* Standardize up_down_meters script
* Add simulation example
* Add parameters to select between lift 0 and 1
* Add example to move using HW IF
* Added example package
* Add simulation example
* Add parameters to select between lift 0 and 1
* Add example to move using HW IF
* Added example package
* Contributors: Luis Camero
```

## ewellix_interfaces

```
* Add new interfaces
* Reset package versions to 0.0.0
* Add interfaces
* Contributors: Luis Camero
```

## ewellix_moveit_config

```
* [ewellix_moveit_config] Fixed package version.
* Updated URDF and MoveIt for mimic joint
* Add moveit config example
* Add moveit config example
* Contributors: Luis Camero, Tony Baltovski
```
