### PR TITLE
clearpath_config: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -85,7 +85,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `1.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## clearpath_config

```
* Added Ewellix Lift (#109 <https://github.com/clearpathrobotics/clearpath_config/issues/109>)
  * Initial add of lifts to config
  * Added ewellix parameters
* Add HE2411 battery support (#110 <https://github.com/clearpathrobotics/clearpath_config/issues/110>)
  * Add support for the HE2411 battery to J100 and A200
  * Add the even-older HE2410 too
* Cherry-pick enable_ekf support from Jazzy (#108 <https://github.com/clearpathrobotics/clearpath_config/issues/108>)
* Fix support for the device_type parameter; previously the camera would always be a Q62 (#99 <https://github.com/clearpathrobotics/clearpath_config/issues/99>) (#101 <https://github.com/clearpathrobotics/clearpath_config/issues/101>)
* Contributors: Chris Iverach-Brereton, luis-camero
```
