### PR TITLE
clearpath_common: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6,6 +6,33 @@ release_platforms:
   ubuntu:
   - noble
 repositories:
+  clearpath_common:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_common.git
+      version: jazzy
+    release:
+      packages:
+      - clearpath_bt_joy
+      - clearpath_common
+      - clearpath_control
+      - clearpath_customization
+      - clearpath_description
+      - clearpath_generator_common
+      - clearpath_manipulators
+      - clearpath_manipulators_description
+      - clearpath_mounts_description
+      - clearpath_platform_description
+      - clearpath_sensors_description
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_common-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_common.git
+      version: jazzy
+    status: developed
   clearpath_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_bt_joy

```
* Improve joy telep support (#131 <https://github.com/clearpathrobotics/clearpath_common/issues/131>)
  * Update description, add bluez dependency
  * Add the quality_cutoff parameter to all of the PS4 configuration files
  * Update the launch file to start the new cutoff node and additional twist_mux
  * Add udev rules for various controllers
  * Add dependency on the new bt cutoff package
  * Add xbox controller parameters for all platforms
  * Fix the PS4/5 axis ordering; the left stick shows up as axis 3/4, with the l/r analogue triggers being 2 & 5. Update omni control configurations accordingly
  * Add PS5 udev rules, config files
  * Add a timeout to the quality lock so we lock out the controller if the quality-checker node crashes
  * Set the respawn flag for the BT cutoff node and the joy_linux node
  * Add additional logging when blocking for services & IPC. Since we've added a timeout to the lock, publish fake quality data when using wired controllers. Log when this happens
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## clearpath_common

```
* Add enable_ekf launch parameter to platform -> localization launch files. Disable the EKF node if enable_ekf is false. (#133 <https://github.com/clearpathrobotics/clearpath_common/issues/133>)
* Added minimum version.
* Remove all references to clearpath_platform
* Move platform.launch.py to clearpath_common metapackage
* Remove all references to clearpath_platform
* Move platform.launch.py to clearpath_common metapackage
* Contributors: Chris Iverach-Brereton, Luis Camero, Tony Baltovski
```

## clearpath_control

```
* Update diff_drive controller settings (#137 <https://github.com/clearpathrobotics/clearpath_common/issues/137>)
  * Update diff_drive controller settings
  * Update all diff_drive settings
* Improve joy telep support (#131 <https://github.com/clearpathrobotics/clearpath_common/issues/131>)
  * Update description, add bluez dependency
  * Add the quality_cutoff parameter to all of the PS4 configuration files
  * Update the launch file to start the new cutoff node and additional twist_mux
  * Add udev rules for various controllers
  * Add dependency on the new bt cutoff package
  * Add xbox controller parameters for all platforms
  * Fix the PS4/5 axis ordering; the left stick shows up as axis 3/4, with the l/r analogue triggers being 2 & 5. Update omni control configurations accordingly
  * Add PS5 udev rules, config files
  * Add a timeout to the quality lock so we lock out the controller if the quality-checker node crashes
  * Set the respawn flag for the BT cutoff node and the joy_linux node
  * Add additional logging when blocking for services & IPC. Since we've added a timeout to the lock, publish fake quality data when using wired controllers. Log when this happens
* Add enable_ekf launch parameter to platform -> localization launch files. Disable the EKF node if enable_ekf is false. (#133 <https://github.com/clearpathrobotics/clearpath_common/issues/133>)
* Fix sensor depends (#129 <https://github.com/clearpathrobotics/clearpath_common/issues/129>)
  * Remove the package initializations that depend on robot packages
  * Add a copy of the imu_filter parameters from clearpath_sensors to clearpath_control. Change the default IMU filter config path to point to this file. Remove more unneeded initializations of clearpath_robot packages
* A300 VCAN (#130 <https://github.com/clearpathrobotics/clearpath_common/issues/130>)
  * A300 vcan1
  * Set vcan0 to be default can interface for lynx control
  * Fix to prevent including the same package multiple times
  * Added filename argument to LaunchFile
  * Linting
* A300 (#118 <https://github.com/clearpathrobotics/clearpath_common/issues/118>)
  * Add A300 meshes
  * Move A300 meshes
  * Add A300 URDF
  * Added A300 control configuration files
  * Remove unstamped parameter, deprecated
  * Use clearpath_hardware_interface LynxHardware
* Fix controller names and kinematics (#109 <https://github.com/clearpathrobotics/clearpath_common/issues/109>)
* Update simulation support for Jazzy (#117 <https://github.com/clearpathrobotics/clearpath_common/issues/117>)
  * Rename gazebo plugins to use new gz nomenclature instead of ign/ignition. Use stamped velocity messages.
  * Restructure the twist_mux yaml file to be more legible, remove the parameters that are overwritten by the launch file anyway
  * Put use_stamped back just for the sake of being explicit. Add use_stamped directly to the launch file
  * Fix the tests to catch unsupported platforms & accessories
* Rename ign_ -> gz_ for gazebo dependencies, comment-out missing jazzy dependencies (for now)
* Removed unstamped remappings
* Set minimum version of teleop_twist_joy to 2.6.1 (the lowest version that supports stamped messages)
* Pass use_stamped to twist_mux
* Remap twist_mux output to stamped cmd_vel
* Pass publish_stamped_twist to joystick teleop node
* Remap stamped cmd_vel controller topic
* Contributors: Chris Iverach-Brereton, Christoph Fröhlich, Luis Camero, Roni Kreinin, Tony Baltovski
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* clearpath_generator_common/clearpath_generator_common/zenoh_router/generator.py (#146 <https://github.com/clearpathrobotics/clearpath_common/issues/146>)
* Use the .profile field for the Zenoh router config; don't add a new variable just for that (#143 <https://github.com/clearpathrobotics/clearpath_common/issues/143>)
* Catch the new unsupported platform/accessory exceptions raised by the generator so the tests pass, use the envar when setting the default value of ROS_DISTRO (#104 <https://github.com/clearpathrobotics/clearpath_common/issues/104>)
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Add Zenoh support (#138 <https://github.com/clearpathrobotics/clearpath_common/issues/138>)
  * Add generator for zenoh router service script
  * Add the ZENOH_ROUTER_CONFIG_URI envar to the generated bash file, populated with either the default path or the user-specified one as needed
* Add enable_ekf launch parameter to platform -> localization launch files. Disable the EKF node if enable_ekf is false. (#133 <https://github.com/clearpathrobotics/clearpath_common/issues/133>)
* Fix test errors (#132 <https://github.com/clearpathrobotics/clearpath_common/issues/132>)
  * Add continue clause to the unsupported device/platform exceptions so we don't try any further tests with them
  * Fix URDF parameters so the source CI passes with the axis cameras
* Add the A200 Observer backpack attachment (#122 <https://github.com/clearpathrobotics/clearpath_common/issues/122>)
  * Add the A200 Observer backpack attachment
* Fix sensor depends (#129 <https://github.com/clearpathrobotics/clearpath_common/issues/129>)
  * Remove the package initializations that depend on robot packages
  * Add a copy of the imu_filter parameters from clearpath_sensors to clearpath_control. Change the default IMU filter config path to point to this file. Remove more unneeded initializations of clearpath_robot packages
* A300 VCAN (#130 <https://github.com/clearpathrobotics/clearpath_common/issues/130>)
  * A300 vcan1
  * Set vcan0 to be default can interface for lynx control
  * Fix to prevent including the same package multiple times
  * Added filename argument to LaunchFile
  * Linting
* Add PTZ sim support (#125 <https://github.com/clearpathrobotics/clearpath_common/issues/125>)
  * Now that axis_camera is released via OSRF, depend on the official package, remove duplicate meshes
  * Rename Gazebo plugins for Jazzy compatibility
  * Modify Axis camera URDFs to using the axis_camera meshes. This lets us control the gazebo topics. Fix the GZ topic names. Camera data is now visible in the simulation
  * Add joint controllers for the pan & tilt actuators. This provides velocity control over the simulated camera
* Add a placeholer URDF for the AMP mount, update meshes (#123 <https://github.com/clearpathrobotics/clearpath_common/issues/123>)
  * Add a placeholer URDF for the AMP mount; STL & final dimensions to come at a later date
  * Default to treaded wheels, flip all the wheel models so the treads visually go in the correct direction
  * Update the top plate, chassis, livery, smooth wheel, and status light meshes. Closes CPE87-2102
  * Catch unsupported platforms/accessories in vcan generation tests
* Update simulation support for Jazzy (#117 <https://github.com/clearpathrobotics/clearpath_common/issues/117>)
  * Rename gazebo plugins to use new gz nomenclature instead of ign/ignition. Use stamped velocity messages.
  * Restructure the twist_mux yaml file to be more legible, remove the parameters that are overwritten by the launch file anyway
  * Put use_stamped back just for the sake of being explicit. Add use_stamped directly to the launch file
  * Fix the tests to catch unsupported platforms & accessories
* Fix the discovery server to use the new path too
* Create ros module to contain default distro & default setup.bash path to make updating distributions easier
* Contributors: Chris Iverach-Brereton, Luis Camero, Roni Kreinin, Tony Baltovski, luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Add PTZ sim support (#125 <https://github.com/clearpathrobotics/clearpath_common/issues/125>)
  * Now that axis_camera is released via OSRF, depend on the official package, remove duplicate meshes
  * Rename Gazebo plugins for Jazzy compatibility
  * Modify Axis camera URDFs to using the axis_camera meshes. This lets us control the gazebo topics. Fix the GZ topic names. Camera data is now visible in the simulation
  * Add joint controllers for the pan & tilt actuators. This provides velocity control over the simulated camera
* Rename ign_ -> gz_ for gazebo dependencies, comment-out missing jazzy dependencies (for now)
* Contributors: Chris Iverach-Brereton, Tony Baltovski, luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Add the A200 Observer backpack attachment (#122 <https://github.com/clearpathrobotics/clearpath_common/issues/122>)
  * Add the A200 Observer backpack attachment
* [clearpath_platform_description] Fixed Ridgeback R100 rear light colour. (#127 <https://github.com/clearpathrobotics/clearpath_common/issues/127>)
* Add PTZ sim support (#125 <https://github.com/clearpathrobotics/clearpath_common/issues/125>)
  * Now that axis_camera is released via OSRF, depend on the official package, remove duplicate meshes
  * Rename Gazebo plugins for Jazzy compatibility
  * Modify Axis camera URDFs to using the axis_camera meshes. This lets us control the gazebo topics. Fix the GZ topic names. Camera data is now visible in the simulation
  * Add joint controllers for the pan & tilt actuators. This provides velocity control over the simulated camera
* Add a placeholer URDF for the AMP mount, update meshes (#123 <https://github.com/clearpathrobotics/clearpath_common/issues/123>)
  * Add a placeholer URDF for the AMP mount; STL & final dimensions to come at a later date
  * Default to treaded wheels, flip all the wheel models so the treads visually go in the correct direction
  * Update the top plate, chassis, livery, smooth wheel, and status light meshes. Closes CPE87-2102
  * Catch unsupported platforms/accessories in vcan generation tests
* A300 (#118 <https://github.com/clearpathrobotics/clearpath_common/issues/118>)
  * Add A300 meshes
  * Move A300 meshes
  * Add A300 URDF
  * Added A300 control configuration files
  * Remove unstamped parameter, deprecated
  * Use clearpath_hardware_interface LynxHardware
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Add collision tags for MoveIt to avoid these objects (#108 <https://github.com/clearpathrobotics/clearpath_common/issues/108>)
* Remove all references to clearpath_platform
* Add collision tags for MoveIt to avoid these objects (#108 <https://github.com/clearpathrobotics/clearpath_common/issues/108>)
* Update simulation support for Jazzy (#117 <https://github.com/clearpathrobotics/clearpath_common/issues/117>)
  * Rename gazebo plugins to use new gz nomenclature instead of ign/ignition. Use stamped velocity messages.
  * Restructure the twist_mux yaml file to be more legible, remove the parameters that are overwritten by the launch file anyway
  * Put use_stamped back just for the sake of being explicit. Add use_stamped directly to the launch file
  * Fix the tests to catch unsupported platforms & accessories
* Rename ign_ -> gz_ for gazebo dependencies, comment-out missing jazzy dependencies (for now)
* Contributors: Chris Iverach-Brereton, Luis Camero, Roni Kreinin, Tony Baltovski, luis-camero
```

## clearpath_sensors_description

```
* Fix test errors (#132 <https://github.com/clearpathrobotics/clearpath_common/issues/132>)
  * Add continue clause to the unsupported device/platform exceptions so we don't try any further tests with them
  * Fix URDF parameters so the source CI passes with the axis cameras
* Add plugins to get the PTZ joint states out of gazebo and into ROS (#126 <https://github.com/clearpathrobotics/clearpath_common/issues/126>)
* Add PTZ sim support (#125 <https://github.com/clearpathrobotics/clearpath_common/issues/125>)
  * Now that axis_camera is released via OSRF, depend on the official package, remove duplicate meshes
  * Rename Gazebo plugins for Jazzy compatibility
  * Modify Axis camera URDFs to using the axis_camera meshes. This lets us control the gazebo topics. Fix the GZ topic names. Camera data is now visible in the simulation
  * Add joint controllers for the pan & tilt actuators. This provides velocity control over the simulated camera
* Update simulation support for Jazzy (#117 <https://github.com/clearpathrobotics/clearpath_common/issues/117>)
  * Rename gazebo plugins to use new gz nomenclature instead of ign/ignition. Use stamped velocity messages.
  * Restructure the twist_mux yaml file to be more legible, remove the parameters that are overwritten by the launch file anyway
  * Put use_stamped back just for the sake of being explicit. Add use_stamped directly to the launch file
  * Fix the tests to catch unsupported platforms & accessories
* Contributors: Chris Iverach-Brereton, Luis Camero, Tony Baltovski, luis-camero
```
