### PR TITLE
micro_ros_agent: 5.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -82,6 +82,12 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
       version: jazzy
     status: maintained
+  micro_ros_agent:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/micro-ROS-Agent-release.git
+      version: 5.0.3-1
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_agent` to `5.0.3-1`:

- upstream repository: https://github.com/clearpathrobotics/micro-ROS-Agent.git
- release repository: https://github.com/clearpath-gbp/micro-ROS-Agent-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## micro_ros_agent

```
* Added spdlog as dep.
* Fix superbuild install permission errors
* Contributors: Błażej Sowa, Tony Baltovski
```
