### PR TITLE
wireless: 1.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -118,5 +118,23 @@ repositories:
       url: https://github.com/clearpathrobotics/simple-term-menu.git
       version: humble
     status: developed
+  wireless:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: jazzy
+    release:
+      packages:
+      - wireless_msgs
+      - wireless_watcher
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/wireless-release.git
+      version: 1.1.2-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: jazzy
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.1.2-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## wireless_msgs

- No changes

## wireless_watcher

```
* Define static type in template (#21 <https://github.com/clearpathrobotics/wireless/issues/21>)
* Contributors: luis-camero
```
