### PR TITLE
umx_driver: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -118,6 +118,21 @@ repositories:
       url: https://github.com/clearpathrobotics/simple-term-menu.git
       version: humble
     status: developed
+  umx_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um7-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: ros2
+    status: maintained
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `umx_driver` to `1.0.1-1`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## umx_driver

```
* Added boost as a build_depend.
* Contributors: Tony Baltovski
```
