### PR TITLE
clearpath_robot: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -67,6 +67,29 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_msgs.git
       version: humble
     status: maintained
+  clearpath_robot:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_robot.git
+      version: jazzy
+    release:
+      packages:
+      - clearpath_diagnostics
+      - clearpath_generator_robot
+      - clearpath_hardware_interfaces
+      - clearpath_robot
+      - clearpath_sensors
+      - lynx_motor_driver
+      - puma_motor_driver
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_robot-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_robot.git
+      version: jazzy
+    status: maintained
   clearpath_ros2_socketcan_interface:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_diagnostics

```
* Fix hard-coded humble packages (#117 <https://github.com/clearpathrobotics/clearpath_robot/issues/117>)
* Contributors: Chris Iverach-Brereton, Luis Camero, Tony Baltovski
```

## clearpath_generator_robot

```
* Add the package initializations that used to be in clearpath_common_generator into the robot generators (#110 <https://github.com/clearpathrobotics/clearpath_robot/issues/110>)
* A300 VCAN (#111 <https://github.com/clearpathrobotics/clearpath_robot/issues/111>)
  * Inventus CAN module ids depending on battery configuration
  * Name each socketcan interface launch file by interface name
  * Pass filename argument to launchfile
* Add dependency on inventus_bmu (#109 <https://github.com/clearpathrobotics/clearpath_robot/issues/109>)
* A300 (#106 <https://github.com/clearpathrobotics/clearpath_robot/issues/106>)
  * Added lynx hardware interface
  * Lynx motor driver
  Rename clearpath_platform namespace to clearpath_hardware_interfaces
  * Added A300 and Inventus battery to generator
  * A300 lighting
  * Dependencies and README
  * Rename platform to hardware_interfaces in hardware.xml
  * Fix append of bms in generator
  * Removed wheel_joints_ map
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Fixed spelling
* Move battery_state to clearpath_hardware_interfaces
* Use clearpath_ros2_socketcan_interface launch files
* Added pointcloud support to OakD
* Catch the new unsupported platform/accessory exceptions in the tests
* Remove missing jazzy dependencies (for now)
* Socket CAN Bridges (#93 <https://github.com/clearpathrobotics/clearpath_robot/issues/93>)
  * Generate can bridges
  * Generate script source robot workspace
  * Remove extra line
  ---------
  Co-authored-by: Roni Kreinin <mailto:rkreinin@clearpathrobotics.com>
* Change puma messages dependency to the new clearpath_motor_msgs
* Use the distribution provided by the common generators
* Contributors: Chris Iverach-Brereton, Luis Camero, Roni Kreinin, Tony Baltovski, luis-camero
```

## clearpath_hardware_interfaces

```
* Fixed motor error lighting sequence (#120 <https://github.com/clearpathrobotics/clearpath_robot/issues/120>)
  * Update motor error lighting sequence if motor_states changes without the lighting state changing
  Added lighting emulator script
  * Removed light emulator
* 1.1.0
* Changes.
* Add HE2410 & HE2411 battery support (#119 <https://github.com/clearpathrobotics/clearpath_robot/issues/119>) (#121 <https://github.com/clearpathrobotics/clearpath_robot/issues/121>)
  * Cherry-pick from Humble
* Add HE2411 battery support (#119 <https://github.com/clearpathrobotics/clearpath_robot/issues/119>)
  * Add support for the HE2410 and HE2411 batteries
* Add visibility_control.h to clearpath_hardware_interfaces, update includes to reference this file (#115 <https://github.com/clearpathrobotics/clearpath_robot/issues/115>)
* A300 lighting fixes (#114 <https://github.com/clearpathrobotics/clearpath_robot/issues/114>)
  * Set NeedsReset to higher priority than Stopped
  Changed NeedsReset lighting pattern
  Set battery message initial values to not trigger battery fault
  Increased low battery lighting sequence duration
  * Updated low battery sequence
* A300 (#106 <https://github.com/clearpathrobotics/clearpath_robot/issues/106>)
  * Added lynx hardware interface
  * Lynx motor driver
  Rename clearpath_platform namespace to clearpath_hardware_interfaces
  * Added A300 and Inventus battery to generator
  * A300 lighting
  * Dependencies and README
  * Rename platform to hardware_interfaces in hardware.xml
  * Fix append of bms in generator
  * Removed wheel_joints_ map
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Apply twist stamped changes
* Remove platform.launch.py
* Move battery_state to clearpath_hardware_interfaces
* Removed config install
* Renamed header directory
* Add clearpath_hardware_interfaces
* Contributors: Chris Iverach-Brereton, Luis Camero, Roni Kreinin, Tony Baltovski
```

## clearpath_robot

```
* [clearpath_robot] Fixed comment.
* [clearpath_robot] Added check for binary install path and fallback to check from a workspace in generate. (#127 <https://github.com/clearpathrobotics/clearpath_robot/issues/127>)
* 1.1.0
* Changes.
* Add dependency for ewellix_driver (#125 <https://github.com/clearpathrobotics/clearpath_robot/issues/125>)
  * Add dependency for ewellix_driver
  * Alphabetical dependencies
* Add zenoh service files & generators (#116 <https://github.com/clearpathrobotics/clearpath_robot/issues/116>)
  * Add zenoh service files & generators
* Remove udev rules for joy controllers (#113 <https://github.com/clearpathrobotics/clearpath_robot/issues/113>)
* A300 (#106 <https://github.com/clearpathrobotics/clearpath_robot/issues/106>)
  * Added lynx hardware interface
  * Lynx motor driver
  Rename clearpath_platform namespace to clearpath_hardware_interfaces
  * Added A300 and Inventus battery to generator
  * A300 lighting
  * Dependencies and README
  * Rename platform to hardware_interfaces in hardware.xml
  * Fix append of bms in generator
  * Removed wheel_joints_ map
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Make robot service always restart vcan
* Add ur_robot_driver dependency
* Add vcan to robot service wants
* Change vcan service to use generated script
* 0.3.2
* Changes.
* [clearpath_robot] Added script to grab diagnostic logs for troublesho… (#84 <https://github.com/clearpathrobotics/clearpath_robot/issues/84>)
  * [clearpath_robot] Added script to grab diagnostic logs for troubleshooting.
  * Make grab-diagnostics script executable and installed
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Remove missing jazzy dependencies (for now)
* Socket CAN Bridges (#93 <https://github.com/clearpathrobotics/clearpath_robot/issues/93>)
  * Generate can bridges
  * Generate script source robot workspace
  * Remove extra line
  ---------
  Co-authored-by: Roni Kreinin <mailto:rkreinin@clearpathrobotics.com>
* Contributors: Chris Iverach-Brereton, Luis Camero, Roni Kreinin, Tony Baltovski, luis-camero
```

## clearpath_sensors

```
* Remap navsatfix to fix (#128 <https://github.com/clearpathrobotics/clearpath_robot/issues/128>)
* 1.1.0
* Changes.
* Remove the image-conversion launch files; they're being relocated to clearpath_offboard_sensors (#118 <https://github.com/clearpathrobotics/clearpath_robot/issues/118>)
* Fix the path for the pointcloud calibration path for Jazzy
* Add support for Axis cameras (#101 <https://github.com/clearpathrobotics/clearpath_robot/issues/101>)
  * Add the axis camera launch file
  * Add the default PTZ dome configuration & pass those parameters by default
  * Set the node name so the parameter namespace resolves correctly
  * Add the complete PTZ config for the dome camera
  * Remap image_raw -> image, ~joint_states -> /robot_namespace/joint_states
  * Add missing / to namespaces
  * Remove the ~ from the namespaces; it's not needed
  * Move the joint_states into the platform namespace
  * Remove duplicate ptz entry
* Move imu_filter.yaml to clearpath_sensors
* Remappings to for Phidget Spatial
* Ffmpeg manual launch (#105 <https://github.com/clearpathrobotics/clearpath_robot/issues/105>)
  * Added manual launch files for encoding/decoding ffmpeg
* Switch remove RGB from pointcloud
* Added pointcloud support to OakD
* Set Blackfly binning as 2 for optimal operation
* Update frame rate to match default in clearpath_config although this rate is always overridden, must be integer
* Restrict image transports on decoded blackfly topics to relevant ones
* Disable all extra image transports on the encoded Blackfly topic
* Add ffmpeg compression support for Blackfly
* 0.3.2
* Changes.
* Add OAKD (#92 <https://github.com/clearpathrobotics/clearpath_robot/issues/92>)
  * Add OAKD
  * Remove unused parameter
  * Add UDEV for OAKD
* Add phidgets spatial (#91 <https://github.com/clearpathrobotics/clearpath_robot/issues/91>)
  * Add phidget spatial config and launch files
  * Add dependency
  * Double to single quotes
* Contributors: Chris Iverach-Brereton, Hilary Luo, Luis Camero, Tony Baltovski, luis-camero
```

## lynx_motor_driver

```
* CAN bootloader fixes (#112 <https://github.com/clearpathrobotics/clearpath_robot/issues/112>)
  * Send boot request to all drivers on action start
  * Removed first ack check
  * Added Ack counter
  * Resend data if counters dont match
  * Make app counter a private variable of driver
  * Re-attempt entering bootloader and alive check 5 times before skipping
  * Fix for skipping unresponsive Lynx's
  * Removed whitespace
* A300 (#106 <https://github.com/clearpathrobotics/clearpath_robot/issues/106>)
  * Added lynx hardware interface
  * Lynx motor driver
  Rename clearpath_platform namespace to clearpath_hardware_interfaces
  * Added A300 and Inventus battery to generator
  * A300 lighting
  * Dependencies and README
  * Rename platform to hardware_interfaces in hardware.xml
  * Fix append of bms in generator
  * Removed wheel_joints_ map
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Contributors: Roni Kreinin
* CAN bootloader fixes (#112 <https://github.com/clearpathrobotics/clearpath_robot/issues/112>)
  * Send boot request to all drivers on action start
  * Removed first ack check
  * Added Ack counter
  * Resend data if counters dont match
  * Make app counter a private variable of driver
  * Re-attempt entering bootloader and alive check 5 times before skipping
  * Fix for skipping unresponsive Lynx's
  * Removed whitespace
* A300 (#106 <https://github.com/clearpathrobotics/clearpath_robot/issues/106>)
  * Added lynx hardware interface
  * Lynx motor driver
  Rename clearpath_platform namespace to clearpath_hardware_interfaces
  * Added A300 and Inventus battery to generator
  * A300 lighting
  * Dependencies and README
  * Rename platform to hardware_interfaces in hardware.xml
  * Fix append of bms in generator
  * Removed wheel_joints_ map
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Contributors: Roni Kreinin
```

## puma_motor_driver

```
* 1.1.0
* Changes.
* Add clearpath_motor_drivers, puma_motor_driver
* Contributors: Luis Camero, Tony Baltovski
```
