### PR TITLE
clearpath_ros2_socketcan_interface: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -99,7 +99,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_ros2_socketcan_interface` to `2.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
- release repository: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## clearpath_ros2_socketcan_interface

```
* Lint launch files (#4 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/4>)
* Prefix node names with can interface
* Add our own launch files that allow us to change namespaces
* Change CI to Humble.
* Contributors: Luis Camero, Roni Kreinin, Tony Baltovski, luis-camero
```
