### PR TITLE
clearpath_robot: 2.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -84,7 +84,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.0.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* Add config and launch for inventus
* Contributors: Luis Camero
```

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

```
* Add config and launch for inventus
* Contributors: Luis Camero
```

## lynx_motor_driver

```
* Multiply feedback velocity by wheel direction (#132 <https://github.com/clearpathrobotics/clearpath_robot/issues/132>)
* Contributors: Roni Kreinin
```

## puma_motor_driver

- No changes
