### PR TITLE
clearpath_desktop: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -48,6 +48,26 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git
       version: jazzy
     status: maintained
+  clearpath_desktop:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_desktop.git
+      version: jazzy
+    release:
+      packages:
+      - clearpath_config_live
+      - clearpath_desktop
+      - clearpath_offboard_sensors
+      - clearpath_viz
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_desktop.git
+      version: jazzy
+    status: maintained
   clearpath_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `2.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_config_live

```
* Apply linting fixes
* Contributors: Chris Iverach-Brereton
```

## clearpath_desktop

```
* Add offboard sensors package (#17 <https://github.com/clearpathrobotics/clearpath_desktop/issues/17>)
  * Add the clearpath_offboard_sensors package, add launch file for offboard velodyne processing
  * Add the image format conversion launch files previously in clearpath_sensors. Update dependencies
* Contributors: Chris Iverach-Brereton
```

## clearpath_offboard_sensors

```
* Add offboard sensors package (#17 <https://github.com/clearpathrobotics/clearpath_desktop/issues/17>)
  * Add the clearpath_offboard_sensors package, add launch file for offboard velodyne processing
  * Add the image format conversion launch files previously in clearpath_sensors. Update dependencies
* Contributors: Chris Iverach-Brereton
```

## clearpath_viz

- No changes
