### PR TITLE
clearpath_nav2_demos: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -87,6 +87,21 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_msgs.git
       version: humble
     status: maintained
+  clearpath_nav2_demos:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
+      version: jazzy
+    status: maintained
   clearpath_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_nav2_demos` to `2.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
- release repository: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_nav2_demos

```
* Enable stamped cmd_vel messages for Nav2
* Add Nav2 config files for A300. Not yet tested on the physical robot (#18 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/18>)
* Remove repos file from CI; it doesn't exist in this repo
* Add source CI
* Update CI for Jazzy
* Fix import ordering, allow shadowing of builtin
* Contributors: Chris Iverach-Brereton
```
