### PR TITLE
clearpath_msgs: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -81,7 +81,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## clearpath_motor_msgs

```
* Added new error flags (#66 <https://github.com/clearpathrobotics/clearpath_msgs/issues/66>)
* Contributors: Roni Kreinin
```

## clearpath_msgs

- No changes

## clearpath_platform_msgs

- No changes
