### PR TITLE
clearpath_robot: 2.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -119,7 +119,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

```
* [clearpath_hardware_interfaces] Fixed BMS topic for fan control. (#145 <https://github.com/clearpathrobotics/clearpath_robot/issues/145>)
* Contributors: Tony Baltovski
```

## clearpath_robot

```
* VCAN fix for Lynx remote request issue (#146 <https://github.com/clearpathrobotics/clearpath_robot/issues/146>)
* Contributors: Roni Kreinin
```

## clearpath_sensors

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
