### PR TITLE
inventus_bms: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -140,6 +140,23 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
       version: jazzy
     status: maintained
+  inventus_bms:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/inventus_bmu.git
+      version: jazzy
+    release:
+      packages:
+      - inventus_bmu
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/inventus_bmu-gbp.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/inventus_bmu.git
+      version: jazzy
+    status: maintained
   micro_ros_agent:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `inventus_bms` to `3.0.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/inventus_bmu.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/inventus_bmu-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## inventus_bmu

```
* Updates for releasing.
* Set supply status to Full when battery indicates it
* Added script to make bin file of script and driver reads in bin now.
* Charging status
* Check that CAN bus is up before attempting to connect
* Power supply health
* Sensor Data QoS
* Initial ROS 2 update.
* Contributors: Roni Kreinin, Tony Baltovski
```
