### PR TITLE
inventus_bms: 3.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -151,7 +151,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/inventus_bmu-gbp.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/inventus_bmu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `inventus_bms` to `3.0.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/inventus_bmu.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/inventus_bmu-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-1`

## inventus_bmu

```
* Removed rclpy from CMakeLists.
* Contributors: Tony Baltovski
```
