### PR TITLE
clearpath_robot: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -167,7 +167,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `1.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* IMU Filter (#134 <https://github.com/clearpathrobotics/clearpath_robot/issues/134>)
  * Add imu_filter launch file and added madgwick entry to filter
  * Add imu filter to generator
  * Rename imu_filter_node to imu_filter_madgwick
* Contributors: luis-camero
```

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

```
* Turn off clearing of SHM on log out (#152 <https://github.com/clearpathrobotics/clearpath_robot/issues/152>) (#156 <https://github.com/clearpathrobotics/clearpath_robot/issues/156>)
  Previously the SHM links were being cleared out when all user sessions ended which was causing ROS communication to fail and the robot to stop working.
* Contributors: Hilary Luo
```

## clearpath_sensors

```
* IMU Filter (#134 <https://github.com/clearpathrobotics/clearpath_robot/issues/134>)
  * Add imu_filter launch file and added madgwick entry to filter
  * Add imu filter to generator
  * Rename imu_filter_node to imu_filter_madgwick
* Contributors: luis-camero
```

## puma_motor_driver

```
* [clearpath_motor_drivers/puma_motor_driver] Fixed copy size.
* Contributors: Tony Baltovski
```
