### PR TITLE
clearpath_config: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -85,7 +85,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `1.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## clearpath_config

```
* Fixed docs link for Robot YAML. (#125 <https://github.com/clearpathrobotics/clearpath_config/issues/125>)
* Add filter to IMU entry (#116 <https://github.com/clearpathrobotics/clearpath_config/issues/116>)
  * Add filter to IMU entry
  * Enable mag only for Phidgets
  * Add DATA topic to Phidget
* Contributors: Tony Baltovski, luis-camero
```
