### PR TITLE
clearpath_robot: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -167,7 +167,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `1.1.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* Fix: Change path to imu_filter to platform config
* Change path to imu_filter to platform config
* Contributors: Luis Camero, Tony Baltovski
```

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

- No changes

## puma_motor_driver

```
* Fix: Robust puma initialization
* Contributors: Stephen Phillips, Tony Baltovski
```
