### PR TITLE
clearpath_msgs: 2.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -81,7 +81,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `2.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## clearpath_motor_msgs

```
* Lynx Warning flags (#68 <https://github.com/clearpathrobotics/clearpath_msgs/issues/68>)
  * Added warning flags
* Contributors: Roni Kreinin
```

## clearpath_msgs

- No changes

## clearpath_platform_msgs

```
* Added temperature indices for all platforms (#69 <https://github.com/clearpathrobotics/clearpath_msgs/issues/69>)
* Contributors: Roni Kreinin
```
