### PR TITLE
clearpath_config: 2.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -42,7 +42,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.1-1`

## clearpath_config

```
* Feature Jazzy Ouster (#132 <https://github.com/clearpathrobotics/clearpath_config/issues/132>)
  * Add OusterOS1
  * Add ouster sample
  * Alphabetical entries to Lidar3D models
* Add D455, D456 to supported devices (#136 <https://github.com/clearpathrobotics/clearpath_config/issues/136>)
* Add support for OAK-D Pro W PoE (#135 <https://github.com/clearpathrobotics/clearpath_config/issues/135>)
  * Add OAK-D Pro W PoE to sensor types. Add IP address field to OAK-D camera class, defaulting to None (for non-PoE models). Add a new assertion to validate IPv4 addresses
  * Support the device_type parameter for OAK-D cameras
  * Add i_mx_id, i_ip for identifying multiple cameras. Fix serial so it maps to i_usb_port_id
  * Rename variable to avoid overwriting python builtin
  * Allow empty strings as well as None for the IP address
  * Add assert_is_ipv4_address to BaseSensor
* Add URDF-only support for the Seyond Robin W (#131 <https://github.com/clearpathrobotics/clearpath_config/issues/131>)
  * Add the SeyondLidar class
  * Add sample for the Seyond Robin W
* Contributors: Chris Iverach-Brereton, luis-camero
```
