### PR TITLE
clearpath_simulator: 2.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -140,6 +140,25 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
       version: jazzy
     status: maintained
+  clearpath_simulator:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_simulator.git
+      version: jazzy
+    release:
+      packages:
+      - clearpath_generator_gz
+      - clearpath_gz
+      - clearpath_simulator
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_simulator.git
+      version: jazzy
+    status: maintained
   clearpath_tests:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `2.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_generator_gz

- No changes

## clearpath_gz

```
* Forward port: Add argument to disable generation  (#75 <https://github.com/clearpathrobotics/clearpath_simulator/issues/75>)
  * Add argument to disable generation (#74 <https://github.com/clearpathrobotics/clearpath_simulator/issues/74>)
* Contributors: luis-camero
```

## clearpath_simulator

- No changes
