### PR TITLE
clearpath_desktop: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -104,7 +104,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 1.0.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `1.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## clearpath_config_live

- No changes

## clearpath_desktop

- No changes

## clearpath_viz

```
* Feature: MoveIt Kinematics (#20 <https://github.com/clearpathrobotics/clearpath_desktop/issues/20>)
  * Use kinematics file to generate parameters for markers
* Fix: handle empty namespace (#19 <https://github.com/clearpathrobotics/clearpath_desktop/issues/19>)
* Contributors: luis-camero
```
