### PR TITLE
clearpath_robot: 2.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -119,7 +119,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.2.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.1-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* Fix/diag remap (#168 <https://github.com/clearpathrobotics/clearpath_robot/issues/168>)
  * Remap diagnostics topic in fan control node
  * Remap diagnostics topic in wireless watcher node
* Contributors: Hilary Luo
```

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

- No changes

## lynx_motor_driver

```
* [clearpath_motor_drivers/lynx_motor_driver] Change action log to debug. (#171 <https://github.com/clearpathrobotics/clearpath_robot/issues/171>)
* Contributors: Tony Baltovski
```

## puma_motor_driver

- No changes
