### PR TITLE
clearpath_tests: 0.2.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -168,7 +168,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_tests-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_tests.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_tests` to `0.2.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_tests.git
- release repository: https://github.com/clearpath-gbp/clearpath_tests-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.3-1`

## clearpath_tests

```
* Reduce the minimum duration for a rotation. Log possible false-positives during the rotation test. Print the calculated duration error for the rotation & drive tests
* Log the version of clearpath_tests in the report
* Increase the length of expected lynx messages to 5, cast the length to an integer before comparing it
* Contributors: Chris Iverach-Brereton
```
