### PR TITLE
clearpath_tests: 0.2.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -168,7 +168,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_tests-release.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_tests.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_tests` to `0.2.6-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_tests.git
- release repository: https://github.com/clearpath-gbp/clearpath_tests-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.5-1`

## clearpath_tests

```
* Add an optional flag for the e-stop, remove key-switch test, add wireless e-stop as an optional component
* Contributors: Chris Iverach-Brereton
```
