### PR TITLE
clearpath_tests: 2.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -168,7 +168,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_tests-release.git
-      version: 0.2.9-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_tests.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_tests` to `2.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_tests.git
- release repository: https://github.com/clearpath-gbp/clearpath_tests-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.9-1`

## clearpath_tests

```
* Allow symlinks to the device handle
* Fix serial MCU tests
* Ensure the firmware is 2.3 or higher to allow fan control; otherwise just skip the fan test
* Add support for lateral driving test for omni platforms (#5 <https://github.com/clearpathrobotics/clearpath_tests/issues/5>)
* Re-enable the fan tests (#4 <https://github.com/clearpathrobotics/clearpath_tests/issues/4>)
* Remove rotation test (#3 <https://github.com/clearpathrobotics/clearpath_tests/issues/3>)
* Contributors: Chris Iverach-Brereton
```
