### PR TITLE
clearpath_common: 2.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -27,7 +27,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.2.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Fix: Handle empty namespace (#187 <https://github.com/clearpathrobotics/clearpath_common/issues/187>)
  * Handle empty namespace
  * Resolve formatting issues
* Contributors: luis-camero
```

## clearpath_manipulators

```
* Fix: Rename ompl to _ompl and update to match Jazzy (#186 <https://github.com/clearpathrobotics/clearpath_common/issues/186>)
* Contributors: luis-camero
```

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
