### PR TITLE
wiferion_charger: 2.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -240,6 +240,24 @@ repositories:
       url: https://github.com/ros-drivers/um7.git
       version: ros2
     status: maintained
+  wiferion_charger:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wiferion_charger.git
+      version: jazzy
+    release:
+      packages:
+      - wiferion_charger
+      - wiferion_interfaces
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/wiferion_charger-release.git
+      version: 2.3.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wiferion_charger.git
+      version: jazzy
+    status: maintained
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wiferion_charger` to `2.3.1-1`:

- upstream repository: https://github.com/clearpathrobotics/wiferion_charger.git
- release repository: https://github.com/clearpath-gbp/wiferion_charger-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## wiferion_charger

```
* Fix/dep with ci (#1 <https://github.com/clearpathrobotics/wiferion_charger/issues/1>)
  * Fixed dependency.
  * Added CI, issues template and codeowners.
  * Fixed linting.
  * Fixed python lint.
* Contributors: Tony Baltovski
```

## wiferion_interfaces

```
* Fix/dep with ci (#1 <https://github.com/clearpathrobotics/wiferion_charger/issues/1>)
  * Fixed dependency.
  * Added CI, issues template and codeowners.
  * Fixed linting.
  * Fixed python lint.
* Contributors: Tony Baltovski
```
