### PR TITLE
clearpath_robot: 2.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -119,7 +119,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.2.4-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.4-1`

## clearpath_diagnostics

```
* Lint: Diagnostic move log to new line (#191 <https://github.com/clearpathrobotics/clearpath_robot/issues/191>)
* Fix/estop diagnostics (#184 <https://github.com/clearpathrobotics/clearpath_robot/issues/184>)
* Feature/clear stale diagnostics (#183 <https://github.com/clearpathrobotics/clearpath_robot/issues/183>)
* Feature/diagnostic categories (#175 <https://github.com/clearpathrobotics/clearpath_robot/issues/175>)
* Feature/inventus diagnostics (#170 <https://github.com/clearpathrobotics/clearpath_robot/issues/170>)
* Contributors: Hilary Luo, Tony Baltovski, Luis Camero
```

## clearpath_generator_robot

```
* Feature: Add UR socat tool communication script (#174 <https://github.com/clearpathrobotics/clearpath_robot/issues/174>) (#179 <https://github.com/clearpathrobotics/clearpath_robot/issues/179>)
* Add exception handlers to the generators for Unsupported* exceptions (#181 <https://github.com/clearpathrobotics/clearpath_robot/issues/181>)
* Move extras launch into a new service (#178 <https://github.com/clearpathrobotics/clearpath_robot/issues/178>)
* Feature/diagnostic categories (#175 <https://github.com/clearpathrobotics/clearpath_robot/issues/175>)
* Feature/inventus diagnostics (#170 <https://github.com/clearpathrobotics/clearpath_robot/issues/170>)
* Contributors: Chris Iverach-Brereton, Hilary Luo, luis-camero
```

## clearpath_hardware_interfaces

```
* [clearpath_hardware_interfaces] Added user fan control and hysteresis when leaving a warning/error state.
* Jazzy dingo and ridgeback fixes (#169 <https://github.com/clearpathrobotics/clearpath_robot/issues/169>)
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_robot

```
* Feature: Add CAN adapters (#192 <https://github.com/clearpathrobotics/clearpath_robot/issues/192>)
* Automatically rerun install script on package update (#193 <https://github.com/clearpathrobotics/clearpath_robot/issues/193>)
* Move symlinks into clearpath-robot.service.wants instead of multi-user.target.wants (#187 <https://github.com/clearpathrobotics/clearpath_robot/issues/187>)
* Add clearpath_tests as dependency for metapackage (#180 <https://github.com/clearpathrobotics/clearpath_robot/issues/180>)
* Move extras launch into a new service (#178 <https://github.com/clearpathrobotics/clearpath_robot/issues/178>)
* Contributors: Chris Iverach-Brereton, Luis Camero
```

## clearpath_sensors

```
* Feature: Wiferion Charger (#194 <https://github.com/clearpathrobotics/clearpath_robot/issues/194>)
* Remap IMU topic to imu/data_raw (per RPSW-2504) (#188 <https://github.com/clearpathrobotics/clearpath_robot/issues/188>)
* Add support for INS sensors + Fixposition XVN (#176 <https://github.com/clearpathrobotics/clearpath_robot/issues/176>)
* Feature/inventus diagnostics (#170 <https://github.com/clearpathrobotics/clearpath_robot/issues/170>)
* Contributors: Chris Iverach-Brereton, Hilary Luo, Luis Camero
```

## lynx_motor_driver

```
* Feature/lynx firmware update process diagnostics (#186 <https://github.com/clearpathrobotics/clearpath_robot/issues/186>)
* Contributors: Hilary Luo
```

## puma_motor_driver

```
* Reduced feedback frequency to 20hz (#195 <https://github.com/clearpathrobotics/clearpath_robot/issues/195>)
* Jazzy dingo and ridgeback fixes (#169 <https://github.com/clearpathrobotics/clearpath_robot/issues/169>)
* Contributors: Roni Kreinin
```
