### PR TITLE
clearpath_robot: 2.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -119,7 +119,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.3.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## clearpath_diagnostics

```
* Remove duplicate and incorrect current / voltage labels (#197 <https://github.com/clearpathrobotics/clearpath_robot/issues/197>)
  The terms "measured voltage" or "measured current" are prepended to these labels where they are used.
* Contributors: Hilary Luo
```

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
