### PR TITLE
cpr_onav_description: 0.1.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -404,7 +404,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_onav_description-release.git
-      version: 0.1.12-1
+      version: 0.1.13-1
     source:
       type: git
       url: https://github.com/cpr-application/cpr_onav_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_onav_description` to `0.1.13-1`:

- upstream repository: https://github.com/cpr-application/cpr_onav_description.git
- release repository: https://github.com/clearpath-gbp/cpr_onav_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.12-1`

## cpr_onav_description

```
* Merge pull request #22 <https://github.com/cpr-application/cpr_onav_description/issues/22> from cpr-application/ONAV-2740
* use matching end tag
* fix sensor type
* use updated ouster driver and description repos
* added ouster lidar link/joint to urdf
* fix arg declaration
* added microstrain gnss links
* added hesai lidar link to urdf
* Contributors: José Mastrangelo
```
