### PR TITLE
video_recorder: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -240,6 +240,26 @@ repositories:
       url: https://github.com/ros-drivers/um7.git
       version: ros2
     status: maintained
+  video_recorder:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/video_recorder.git
+      version: jazzy-devel
+    release:
+      packages:
+      - audio_recorder
+      - audio_recorder_msgs
+      - video_recorder
+      - video_recorder_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/video_recorder-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/video_recorder.git
+      version: jazzy-devel
+    status: maintained
   wiferion_charger:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_recorder` to `2.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/video_recorder.git
- release repository: https://github.com/clearpath-gbp/video_recorder-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## audio_recorder

```
* Add missing dependencies
* Contributors: Chris Iverach-Brereton
```

## audio_recorder_msgs

```
* Remove old ROS1 depends
* Contributors: Chris Iverach-Brereton
```

## video_recorder

```
* Remove old ROS1 depends
* Contributors: Chris Iverach-Brereton
```

## video_recorder_msgs

```
* Remove old ROS1 depends
* Contributors: Chris Iverach-Brereton
```
