### PR TITLE
video_recorder: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -254,7 +254,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/video_recorder-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/video_recorder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_recorder` to `2.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/video_recorder.git
- release repository: https://github.com/clearpath-gbp/video_recorder-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## audio_recorder

- No changes

## audio_recorder_msgs

- No changes

## video_recorder

```
* Remove boost from build file; it's not actually used (#8 <https://github.com/clearpathrobotics/video_recorder/issues/8>)
* Contributors: Chris Iverach-Brereton
```

## video_recorder_msgs

- No changes
