### PR TITLE
clearpath_robot: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -114,12 +114,13 @@ repositories:
       - clearpath_hardware_interfaces
       - clearpath_robot
       - clearpath_sensors
+      - clearpath_tests
       - lynx_motor_driver
       - puma_motor_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.3.3-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.4.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.3-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* Added a software based low voltage cut-off for the A300. (#185 <https://github.com/clearpathrobotics/clearpath_robot/issues/185>)
* Pinout control node (#198 <https://github.com/clearpathrobotics/clearpath_robot/issues/198>)
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_hardware_interfaces

```
* Added a software based low voltage cut-off for the A300. (#185 <https://github.com/clearpathrobotics/clearpath_robot/issues/185>)
* Pinout control node (#198 <https://github.com/clearpathrobotics/clearpath_robot/issues/198>)
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_robot

- No changes

## clearpath_sensors

- No changes

## clearpath_tests

```
* Fix A300 fans test (#204 <https://github.com/clearpathrobotics/clearpath_robot/issues/204>)
* Add additional allowed warnings/errors for specific platforms (#202 <https://github.com/clearpathrobotics/clearpath_robot/issues/202>)
* Reduce strafe distance, increase strafe speed (#203 <https://github.com/clearpathrobotics/clearpath_robot/issues/203>)
* Move clearpath_tests into clearpath_robot (#201 <https://github.com/clearpathrobotics/clearpath_robot/issues/201>)
* Contributors: Chris Iverach-Brereton
```

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
