### PR TITLE
clearpath_nav2_demos: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -96,7 +96,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
-      version: 2.0.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_nav2_demos` to `2.4.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
- release repository: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## clearpath_nav2_demos

```
* Update nav2 configuration files for Jazzy (#21 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/21>)
* use_sim_time should not be in the yaml in Jazzy (#19 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/19>)
* Contributors: Chris Iverach-Brereton, Hilary Luo
```
