### PR TITLE
wiferion_charger: 2.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -258,7 +258,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/wiferion_charger-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/wiferion_charger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wiferion_charger` to `2.3.2-1`:

- upstream repository: https://github.com/clearpathrobotics/wiferion_charger.git
- release repository: https://github.com/clearpath-gbp/wiferion_charger-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.1-1`

## wiferion_charger

- No changes

## wiferion_interfaces

```
* Add ament_cmake to package.xml
* Contributors: Luis Camero
```
