### PR TITLE
canopen_inventus: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6,6 +6,24 @@ release_platforms:
   ubuntu:
   - noble
 repositories:
+  canopen_inventus:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/canopen_inventus.git
+      version: jazzy
+    release:
+      packages:
+      - canopen_inventus_driver
+      - canopen_inventus_interfaces
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/canopen_inventus-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/canopen_inventus.git
+      version: jazzy
+    status: developed
   clearpath_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canopen_inventus` to `0.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/canopen_inventus.git
- release repository: https://github.com/clearpath-gbp/canopen_inventus-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## canopen_inventus_driver

```
* Update maintainer, description, and license
* Update headers
* Only publish when data is available
* Remove inputs
* Remove inventus_bmu
* Remove dependency from CMakeLists
* Remove dependency on inventus_bmu
* Update dependencies
* Add license headers
* Hide ProxyDriver topics
* Do not check reserved fault bits
* Remove logging in boot
* Add conversion methods
* Switch to using indices and maps to store data
* Separate read and publish loops
* Add comments
* Rework to use typed structures
* Initial add of Inventus CANOpen driver
* Contributors: Luis Camero
```

## canopen_inventus_interfaces

```
* Add build_type ament_cmake
* Rework to use typed structures
* Contributors: Luis Camero
```
