### PR TITLE
canopen_inventus_bringup: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -24,6 +24,21 @@ repositories:
       url: https://github.com/clearpathrobotics/canopen_inventus.git
       version: jazzy
     status: developed
+  canopen_inventus_bringup:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/canopen_inventus_bringup.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/canopen_inventus_bringup-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/canopen_inventus_bringup.git
+      version: jazzy
+    status: developed
   clearpath_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canopen_inventus_bringup` to `0.1.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/canopen_inventus_bringup.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/canopen_inventus_bringup-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## canopen_inventus_bringup

```
* Update maintaner, description, and license
* Prune dependencies
* Add license header to launch file
* Add license header to source files
* Add header to include
* Add license file
* Increase publish loop 100 hz, will not publish if data is not available
* Add descriptions to launch arguments
* Update dependencies
* Remove debug print
* Change default battery count to 1
* Add arguments to change battery count and IDs
* Add writer to CMakeLists
* Add writer to bringup
* Increase publish rate decrease read rate
* Add namesapce argument
* Remove dcfgen in CMakeLists
* Use aliases in bus.yml
* Add eds_writer
* Lint bringup package
* Use 50 ms read periods
* Increase read loop speed
* Rework to use typed structures
* Initial add of Inventus CANOpen driver
* Contributors: Luis Camero
```
