### PR TITLE
ros2_canopen: 0.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -214,6 +214,26 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/micro-ROS-Agent-release.git
       version: 5.0.3-1
+  ros2_canopen:
+    release:
+      packages:
+      - canopen
+      - canopen_402_driver
+      - canopen_base_driver
+      - canopen_core
+      - canopen_fake_slaves
+      - canopen_interfaces
+      - canopen_master_driver
+      - canopen_proxy_driver
+      - canopen_ros2_control
+      - canopen_ros2_controllers
+      - canopen_tests
+      - canopen_utils
+      - lely_core_libraries
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpathrobotics/ros2_canopen-release.git
+      version: 0.3.1-1
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.3.1-1`:

- upstream repository: https://github.com/clearpathrobotics/ros2_canopen.git
- release repository: https://github.com/clearpathrobotics/ros2_canopen-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## canopen

```
* update documentation
* Contributors: ipa-vsp
```

## canopen_402_driver

```
* Run pre-commit process
* Whitespace fixes.
* Don't overwrite value, print on read
* Attempt to make homing timeout a parameter in seconds
  This should be changed later to support a more robust duration instead
  of int seconds
* Add services to disable/enable motor so that brake is usable.
* Add services to disable/enable motor so that brake is usable.
* Contributors: Gerry Salinas, gerry, zlizer
```

## canopen_base_driver

```
* Add boot timeout parameter to lely driver
* Contributors: Luis Camero
```

## canopen_core

```
* pre-commit update
* fix namespace setting from bus config
* Add namespacing support
* Contributors: Christoph Hellmann Santos, ipa-vsp
```

## canopen_fake_slaves

```
* Add suported modes to canopen_fake_slaves README (#337 <https://github.com/clearpathrobotics/ros2_canopen/issues/337>)
* Contributors: Patrick Roncagliolo
```

## canopen_interfaces

- No changes

## canopen_master_driver

- No changes

## canopen_proxy_driver

- No changes

## canopen_ros2_control

```
* Fixing ID type in storage of ros2_control system.
* Contributors: Dr. Denis
```

## canopen_ros2_controllers

```
* Fix command interfaces value missmatch.
* fix header file
* Contributors: Marco A. Gutierrez, ipa-vsp
```

## canopen_tests

```
* update documentation
* Add test prototype
* Add namespacing support
* Contributors: Christoph Hellmann Santos, ipa-vsp
```

## canopen_utils

- No changes

## lely_core_libraries

```
* Do not export deprecated Lely IO library (#318 <https://github.com/clearpathrobotics/ros2_canopen/issues/318>)
* Update lely-core into CMakeLists.txt (#307 <https://github.com/clearpathrobotics/ros2_canopen/issues/307>)
  fix typo in mkjmp documentation
  stop SYNC timer and receiver in co_sync_stop()
  Docker - adding back support for building docker images for old GCC
* Update .pre-commit-config.yaml (#303 <https://github.com/clearpathrobotics/ros2_canopen/issues/303>)
  * Update .pre-commit-config.yaml
  updated libs
  * Update cogen.py
* Contributors: Patrick Roncagliolo, mosfet80
```
