### PR TITLE
canopen_inventus: 0.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -18,7 +18,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/canopen_inventus-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/canopen_inventus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `canopen_inventus` to `0.1.2-1`:

- upstream repository: https://github.com/clearpathrobotics/canopen_inventus.git
- release repository: https://github.com/clearpath-gbp/canopen_inventus-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## canopen_inventus_driver

```
* Updated package.xml to be BSD-3-Clause licence.
* Contributors: Tony Baltovski
```

## canopen_inventus_interfaces

```
* Updated package.xml to be BSD-3-Clause licence.
* Contributors: Tony Baltovski
```
