### PR TITLE
canopen_inventus_bringup: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -33,7 +33,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/canopen_inventus_bringup-gbp.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/canopen_inventus_bringup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `canopen_inventus_bringup` to `0.1.1-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/canopen_inventus_bringup.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/canopen_inventus_bringup-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`

## canopen_inventus_bringup

```
* Increase SDO timeout and decrease read speeds
* Contributors: Luis Camero
```
