### PR TITLE
clearpath_robot: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -153,7 +153,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.4.1-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.5.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.1-1`

## clearpath_generator_robot

```
* Feature: ros2_canopen Inventus driver switch  (#216 <https://github.com/clearpathrobotics/clearpath_robot/issues/216>)
  * Add canopen_inventus launch to generator
  * Add canopen_inventus_bringup dependency
  * Add canopen_inventus_bringup to CI rosdep key ignore
  * Remove inventus_bmu config and launch
  * Remove unused import
* Add foxglove bridge launch to platform service launch (#217 <https://github.com/clearpathrobotics/clearpath_robot/issues/217>)
* Add wireless watcher based on enable flag (#218 <https://github.com/clearpathrobotics/clearpath_robot/issues/218>)
* Feature: CAN Bridge Parameters (#210 <https://github.com/clearpathrobotics/clearpath_robot/issues/210>)
* Renamed to low soc cutoff from low voltage cutoff and fixed service client name.
  * Renamed to low soc cutoff from low voltage cutoff and fixed service client name.
  * Fixed generator member.
* Contributors: Hilary Luo, Tony Baltovski, luis-camero
```

## clearpath_hardware_interfaces

```
* Renamed to low soc cutoff from low voltage cutoff and fixed service client name.
  * Renamed to low soc cutoff from low voltage cutoff and fixed service client name.
  * Fixed generator member.
* Contributors: Tony Baltovski
```

## clearpath_robot

```
* Fix: Post-Install Permissions (#219 <https://github.com/clearpathrobotics/clearpath_robot/issues/219>)
* Move clearpath_diagnostics to clearpath_common (#213 <https://github.com/clearpathrobotics/clearpath_robot/issues/213>)
* Feature: Add udev entry to catch usbcan adapters (#207 <https://github.com/clearpathrobotics/clearpath_robot/issues/207>)
* Contributors: Hilary Luo, luis-camero
```

## clearpath_sensors

```
* Fix: Wiferion Charger Dependency (#221 <https://github.com/clearpathrobotics/clearpath_robot/issues/221>)
  Add wiferion_charger dependency to clearpath_sensors
* Feature: ros2_canopen Inventus driver switch  (#216 <https://github.com/clearpathrobotics/clearpath_robot/issues/216>)
  * Add canopen_inventus launch to generator
  * Add canopen_inventus_bringup dependency
  * Add canopen_inventus_bringup to CI rosdep key ignore
  * Remove inventus_bmu config and launch
  * Remove unused import
* Contributors: luis-camero
```

## clearpath_tests

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
