### PR TITLE
lms1xx: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -208,6 +208,21 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/research/inventus_bmu.git
       version: jazzy
     status: maintained
+  lms1xx:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/LMS1xx.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/LMS1xx-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/LMS1xx.git
+      version: humble-devel
+    status: maintained
   micro_ros_agent:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `1.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/LMS1xx-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## lms1xx

```
* Added statemachine to prevent driver from blocking executor.
* Contributors: Roni Kreinin
```
