### PR TITLE
valence_bms: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -342,7 +342,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
-      version: 1.0.2-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/valence_bms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `valence_bms` to `1.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/valence_bms.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## valence_bms_driver

```
* Fix indentation
* Remove testing log
* Do not use bms_functionality to set supply status
* Add leading backspace
* Retrieve system status variables
* Remap battery state
* Fix socketcan receiver launch
* Update launch file
* Get battery status and health
* Also move current and voltage
* Retrieve data before it is wiped
* Initial add of BatteryState message
* Contributors: Luis Camero
```

## valence_bms_msgs

- No changes
