### PR TITLE
clearpath_robot: 1.3.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -167,7 +167,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `1.3.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.1-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* Fix/Feature: Valence Battery Update/Fix (#227 <https://github.com/clearpathrobotics/clearpath_robot/issues/227>)
  * Only add battery estimator when no battery driver
  * Update valence arguments
  * Fix valence launch filename
  * Remove duplicate definition
  * Add robot namespace argument
* Contributors: luis-camero
```

## clearpath_hardware_interfaces

```
* Populate A200 MCU status messages (#223 <https://github.com/clearpathrobotics/clearpath_robot/issues/223>)
* Contributors: Chris Iverach-Brereton
```

## clearpath_robot

- No changes

## clearpath_sensors

- No changes

## puma_motor_driver

- No changes
