### PR TITLE
valence_bmu: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -294,6 +294,24 @@ repositories:
       url: https://github.com/ros-drivers/um7.git
       version: ros2
     status: maintained
+  valence_bmu:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/valence_bms.git
+      version: main
+    release:
+      packages:
+      - valence_bms_driver
+      - valence_bms_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/valence_bms.git
+      version: main
+    status: maintained
   video_recorder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `valence_bmu` to `1.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/valence_bms.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/valence_bms-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## valence_bms_driver

```
* Fix indentation
* Remove testing log
* Do not use bms_functionality to set supply status
* Add leading backspace
* Retrieve system status variables
* Remap battery state
* Fix socketcan receiver launch
* Update launch file
* Get battery status and health
* Also move current and voltage
* Retrieve data before it is wiped
* Initial add of BatteryState message
* Contributors: Luis Camero
```

## valence_bms_msgs

- No changes
