### PR TITLE
clearpath_robot: 2.5.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -153,7 +153,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.5.0-1
+      version: 2.5.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.5.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

```
* Populate the A200 MCU status messages (#224 <https://github.com/clearpathrobotics/clearpath_robot/issues/224>)
* Contributors: Chris Iverach-Brereton
```

## clearpath_robot

```
* Fix: Post Install  (#225 <https://github.com/clearpathrobotics/clearpath_robot/issues/225>)
  * Do not create any dummy directories on launch files
  * Run install script as root
* Contributors: luis-camero
```

## clearpath_sensors

- No changes

## clearpath_tests

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
