### PR TITLE
ros2_canopen: 0.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -248,7 +248,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpathrobotics/ros2_canopen-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.3.2-1`:

- upstream repository: https://github.com/clearpathrobotics/ros2_canopen.git
- release repository: https://github.com/clearpathrobotics/ros2_canopen-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-1`

## canopen

- No changes

## canopen_402_driver

- No changes

## canopen_base_driver

```
* Add timeout to conditional variable waits
* Fix error throw
* Handle error codes in LelyDriverBridge
* Contributors: Luis Camero
```

## canopen_core

- No changes

## canopen_fake_slaves

- No changes

## canopen_interfaces

- No changes

## canopen_master_driver

```
* Add timeout to conditional variable waits
* Contributors: Luis Camero
```

## canopen_proxy_driver

- No changes

## canopen_ros2_control

- No changes

## canopen_ros2_controllers

- No changes

## canopen_tests

- No changes

## canopen_utils

- No changes

## lely_core_libraries

```
* Switch to clearpathrobotics/lely-core
* Switch lely-core repository
* Contributors: Luis Camero
```
