### PR TITLE
canfestival_ros: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - noble
 repositories:
+  canfestival_ros:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
+      version: jazzy
+    status: maintained
   canopen_inventus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canfestival_ros` to `1.1.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/research/canfestival_ros.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/canfestival_ros-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## canfestival_ros

```
* Remove dep on objdict
* Contributors: Luis Camero
```
