### PR TITLE
sevcon_ros: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -279,6 +279,24 @@ repositories:
       url: https://github.com/clearpathrobotics/serial-ros2.git
       version: master
     status: maintained
+  sevcon_ros:
+    doc:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: jazzy
+    release:
+      packages:
+      - sevcon_ros
+      - sevcon_traction
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
+      version: jazzy
+    status: maintained
   simple_term_menu_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sevcon_ros` to `1.1.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/sevcon_ros.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/sevcon_ros-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## sevcon_ros

- No changes

## sevcon_traction

```
* Remove dependency on python2 tools
* Contributors: Luis Camero
```
