### PR TITLE
clearpath_common: 1.3.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -70,7 +70,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `1.3.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.2-1`

## clearpath_common

- No changes

## clearpath_control

```
* Add missing linear.y teleop parameters, adjust logitech gains to match equivalents from ps4 configuration (#220 <https://github.com/clearpathrobotics/clearpath_common/issues/220>)
* Contributors: Chris Iverach-Brereton
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Feature: Manipulator Extra ROS Parameters (#229 <https://github.com/clearpathrobotics/clearpath_common/issues/229>)
  * Pass manipulator ros parameters to generated controller file
  * Update platform config parameters
  * Remove pprint
* Fix/Feature: UR Arm Controller Update Rate (#225 <https://github.com/clearpathrobotics/clearpath_common/issues/225>)
  * Change controller update rate for universal robots to 500
  * Use UniversalRobots update_rate parameters if available
* Contributors: luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Fix/Feature: UR Arm Controller Update Rate (#225 <https://github.com/clearpathrobotics/clearpath_common/issues/225>)
  * Change controller update rate for universal robots to 500
  * Use UniversalRobots update_rate parameters if available
* Contributors: luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
