### PR TITLE
clearpath_common: 2.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -76,7 +76,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.5.1-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.6.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.1-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

```
* Re-enable publishing controller input to joy_teleop/cmd_vel (#232 <https://github.com/clearpathrobotics/clearpath_common/issues/232>)
* Fix: W200 Diff Drive Parameters (#228 <https://github.com/clearpathrobotics/clearpath_common/issues/228>)
  * Disable using position for odom
  * Lower acceleration to reasonable values
* Feature/lynx 1.0.0 (#226 <https://github.com/clearpathrobotics/clearpath_common/issues/226>)
  * Added deceleration limits to A300
  * Update to A300 angular parameters
  * Reduced angular velocity defaults for controllers
* Drop A200 controller manager update rate (#224 <https://github.com/clearpathrobotics/clearpath_common/issues/224>)
  the update rate is limited by the mcu capabilities
* Contributors: Chris Iverach-Brereton, Hilary Luo, Roni Kreinin, luis-camero
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

```
* Add foxglove dependency (#230 <https://github.com/clearpathrobotics/clearpath_common/issues/230>)
* Fix/expected diag rates (#227 <https://github.com/clearpathrobotics/clearpath_common/issues/227>)
  * loosen rate window for MCU to allow 1 message to be missed
  * Add lighting category to diagnostics aggregator conditionally
  * Set expected BMS Status rate based on battery type
  * Only create the Odometry category if ekf set true
  * Only create the Networking category if wireless watcher is enabled
  * Configurable tolerance window on diagnostics
  * Monitor estop instead of stop_status if stop status does not exist
  * Safety check for size of the labels lists
  * Add warning on estop status
  * Disable stop status rate by platform
* Contributors: Hilary Luo, luis-camero
```

## clearpath_generator_common

```
* Fix/expected diag rates (#227 <https://github.com/clearpathrobotics/clearpath_common/issues/227>)
  * loosen rate window for MCU to allow 1 message to be missed
  * Add lighting category to diagnostics aggregator conditionally
  * Set expected BMS Status rate based on battery type
  * Only create the Odometry category if ekf set true
  * Only create the Networking category if wireless watcher is enabled
  * Configurable tolerance window on diagnostics
  * Monitor estop instead of stop_status if stop status does not exist
  * Safety check for size of the labels lists
  * Add warning on estop status
  * Disable stop status rate by platform
* Use argparse instead of getopt for processing the command-line arguments (#223 <https://github.com/clearpathrobotics/clearpath_common/issues/223>)
* Add A300 AMP attachments (#200 <https://github.com/clearpathrobotics/clearpath_common/issues/200>)
  * Add meshes, URDFs for the A300 AMP and AMP Observer attachments
  * Add spotlight attachment with light plugin for simulation
  * Add Seyond description with lower-than-reality resolution & correct FoV for simulation. Fix math for calculating the number of samples
  * Add GPS plugins for the Fixposition description
* Contributors: Chris Iverach-Brereton, Hilary Luo
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Add the third antenna (bluetooth) to the top of the AMP frame (#231 <https://github.com/clearpathrobotics/clearpath_common/issues/231>)
* Add A300 AMP attachments (#200 <https://github.com/clearpathrobotics/clearpath_common/issues/200>)
  * Add meshes, URDFs for the A300 AMP and AMP Observer attachments
  * Add spotlight attachment with light plugin for simulation
  * Add Seyond description with lower-than-reality resolution & correct FoV for simulation. Fix math for calculating the number of samples
  * Add GPS plugins for the Fixposition description
* Contributors: Chris Iverach-Brereton
```

## clearpath_sensors_description

```
* Add A300 AMP attachments (#200 <https://github.com/clearpathrobotics/clearpath_common/issues/200>)
  * Add meshes, URDFs for the A300 AMP and AMP Observer attachments
  * Add spotlight attachment with light plugin for simulation
  * Add Seyond description with lower-than-reality resolution & correct FoV for simulation. Fix math for calculating the number of samples
  * Add GPS plugins for the Fixposition description
* Contributors: Chris Iverach-Brereton
```
