### PR TITLE
clearpath_robot: 2.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -168,7 +168,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.5.1-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.6.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.1-1`

## clearpath_generator_robot

```
* Enable dependency on sevcon and valence bms
* Contributors: Luis Camero
```

## clearpath_hardware_interfaces

```
* Lynx 1.0.0 (#235 <https://github.com/clearpathrobotics/clearpath_robot/issues/235>)
  * Multiple boot request attempts
  * Added travel field to feedback
  Use travel for odometry
  * Apply direction to travel
  * Added odometry reset to lynx_motor_driver
  * Record last travel data
  * Last travel in header
  * Renamed service to reset_travel
  * Limit wheel velocity based on system protection max speed
  * Added 1.0.0 bin
* Contributors: Roni Kreinin
```

## clearpath_robot

```
* [clearpath_robot] Updated grab-diagnostics to latest. (#231 <https://github.com/clearpathrobotics/clearpath_robot/issues/231>)
* Contributors: Tony Baltovski
```

## clearpath_sensors

```
* [clearpath_sensors] Fixed missing dependency lms1xx. (#233 <https://github.com/clearpathrobotics/clearpath_robot/issues/233>)
* Contributors: Tony Baltovski
```

## clearpath_tests

```
* Fix expected number of CAN devices for W200 tests (#241 <https://github.com/clearpathrobotics/clearpath_robot/issues/241>)
* Add wireless e-stop test to W200 tests (#240 <https://github.com/clearpathrobotics/clearpath_robot/issues/240>)
* Feature/expand diagnostic test (#236 <https://github.com/clearpathrobotics/clearpath_robot/issues/236>)
  * Remove diagnostic exceptions
  * Check for stale diagnostics
  * Ignore mecanum drive bug for now
* Enable wireless e-stop test on W200 (#226 <https://github.com/clearpathrobotics/clearpath_robot/issues/226>)
  W200 includes a wireless e-stop (non-optional) that should be included in the tests.
* Fix clearpath_tests so they don't crash/hang under certain conditions, remove unnecessary code (#220 <https://github.com/clearpathrobotics/clearpath_robot/issues/220>)
  * Add a new class to handle timeouts to reduce duplication
  * Remove node-specific mains, remove .start() from the TestNode class
  * Implement timeout in MCU test so it doesn't hang forever
  * Remove unnecessary functions from canbus test
  * Implement the new timeout for estop tests. Add an abort() method to kill long-running threads so we don't block for too long. Remove unused import
  * Implement new timeout in linear acceleration test
  * Implement new timeout in rotation test
  * Fix a parser error that occurs if wifi is turned off
  * Move motor currents initialization to constructor, call .start() in the linear acceleration test
  * Change how we calculate the IMU inclination; calculate the inclination and calculate the error based on that, rather than percentage error bars based on the vector
  * Fix the logging for the linear acceleration test
  * Test the direction & magnitude of the angular velocity separately. Fix some extra parentheses in the results
* Contributors: Chris Iverach-Brereton, Hilary Luo
```

## lynx_motor_driver

```
* Updated lynx bin to 1.0.1 (#237 <https://github.com/clearpathrobotics/clearpath_robot/issues/237>)
* Lynx 1.0.0 (#235 <https://github.com/clearpathrobotics/clearpath_robot/issues/235>)
  * Multiple boot request attempts
  * Added travel field to feedback
  Use travel for odometry
  * Apply direction to travel
  * Added odometry reset to lynx_motor_driver
  * Record last travel data
  * Last travel in header
  * Renamed service to reset_travel
  * Limit wheel velocity based on system protection max speed
  * Added 1.0.0 bin
* Contributors: Roni Kreinin
```

## puma_motor_driver

- No changes
