### PR TITLE
clearpath_common: 2.6.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -76,7 +76,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.6.2-1
+      version: 2.6.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.6.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.2-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

- No changes

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Fix: Ewellix Gazebo Migration (#236 <https://github.com/clearpathrobotics/clearpath_common/issues/236>)
* Contributors: luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Fix: Disable Platform Controllers in Manipulator Controllers (#239 <https://github.com/clearpathrobotics/clearpath_common/issues/239>)
  Add flag to disable platform controllers for manipulation controller manager
* Contributors: luis-camero
```

## clearpath_sensors_description

- No changes
