### PR TITLE
socketcan_adapter: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -312,6 +312,21 @@ repositories:
       url: https://github.com/clearpathrobotics/simple-term-menu.git
       version: humble
     status: developed
+  socketcan_adapter:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/socketcan_adapter.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/socketcan_adapter-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/socketcan_adapter.git
+      version: jazzy
+    status: maintained
   umx_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `socketcan_adapter` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/socketcan_adapter.git
- release repository: https://github.com/clearpath-gbp/socketcan_adapter-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## socketcan_adapter

```
* Merge branch '1-port-socketcan-adapter-to-publishable-repository' into 'main'
  Resolve "Port Socketcan Adapter to Publishable Repository"
  Closes #1 <https://github.com/clearpathrobotics/socketcan_adapter/issues/1>
  See merge request polymathrobotics/socketcan_adapter!1
* Resolve "Port Socketcan Adapter to Publishable Repository"
* Initial commit
* Contributors: Amazing Betty-Anne, Zeerek Ahmad
```
