### PR TITLE
socketcan_adapter: 0.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -321,7 +321,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/socketcan_adapter-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/socketcan_adapter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `socketcan_adapter` to `0.2.2-1`:

- upstream repository: https://github.com/clearpathrobotics/socketcan_adapter.git
- release repository: https://github.com/clearpath-gbp/socketcan_adapter-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-1`

## socketcan_adapter

```
* Disabled tests for now.
* Contributors: Tony Baltovski
```
