### PR TITLE
clearpath_robot: 1.3.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -167,7 +167,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 1.3.3-1
+      version: 1.3.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `1.3.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.3-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

```
* [clearpath_robot] Added getting the robot.yaml file to the grab-diagnostics script. (#244 <https://github.com/clearpathrobotics/clearpath_robot/issues/244>)
* Contributors: Tony Baltovski
```

## clearpath_sensors

```
* Remap navsatfix to fix (#128 <https://github.com/clearpathrobotics/clearpath_robot/issues/128>) (#251 <https://github.com/clearpathrobotics/clearpath_robot/issues/251>)
  Co-authored-by: Chris Iverach-Brereton <mailto:59611394+civerachb-cpr@users.noreply.github.com>
* Contributors: Tony Baltovski
```

## puma_motor_driver

- No changes
