### PR TITLE
clearpath_config: 2.6.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -91,7 +91,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.6.1-1
+      version: 2.6.2-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.6.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.1-1`

## clearpath_config

```
* Fix: Overwrite defined values with ROS parameters (#182 <https://github.com/clearpathrobotics/clearpath_config/issues/182>)
  * Overwrite defined values with ROS parameters
  * Remove comment
* Changed sample username to robot.
* Contributors: Tony Baltovski, luis-camero
```
