### PR TITLE
clearpath_robot: 1.3.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -167,7 +167,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 1.3.4-1
+      version: 1.3.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `1.3.5-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.4-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

```
* Feature: Franka Hand (#252 <https://github.com/clearpathrobotics/clearpath_robot/issues/252>)
  * Add frank gripper launch
  * Add manipulators to namespace
  * Add remapping of joint states
  * Fix joint names
* Contributors: luis-camero
```

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

- No changes

## puma_motor_driver

- No changes
