### PR TITLE
clearpath_robot: 2.6.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -168,7 +168,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.6.2-1
+      version: 2.6.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.6.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.2-1`

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

```
* [clearpath_robot] Changed default service user to robot from administrator. (#248 <https://github.com/clearpathrobotics/clearpath_robot/issues/248>)
* Contributors: Tony Baltovski
```

## clearpath_sensors

```
* Add missing dependency (#258 <https://github.com/clearpathrobotics/clearpath_robot/issues/258>)
* Fix/image remaps (#257 <https://github.com/clearpathrobotics/clearpath_robot/issues/257>)
  * Add remaps for additional image transports
  * Add missing mono remap
* Correct default oakd config file (#255 <https://github.com/clearpathrobotics/clearpath_robot/issues/255>)
* Contributors: Hilary Luo
```

## clearpath_tests

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
