### PR TITLE
ewellix_lift: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -208,6 +208,24 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_simulator.git
       version: jazzy
     status: maintained
+  ewellix_lift:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/ewellix_lift.git
+      version: jazzy
+    release:
+      packages:
+      - ewellix_driver
+      - ewellix_examples
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/ewellix_lift-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/ewellix_lift.git
+      version: jazzy
+    status: maintained
   ewellix_lift_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ewellix_lift` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/ewellix_lift.git
- release repository: https://github.com/clearpath-gbp/ewellix_lift-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ewellix_driver

```
* Update license in package.xml
* Merge pull request #7 <https://github.com/clearpathrobotics/ewellix_lift/issues/7> from Ayush1285/feat/last-position
  Update the initial state of the lift.
* Merge pull request #4 <https://github.com/clearpathrobotics/ewellix_lift/issues/4> from Ayush1285/humble
  Encoder limits as configurable parameters
* Fetch prev position
* Added encoder limit struct
* Added upper and lower limits as member variables
* Added encoder lower and upper limits params.
* Contributors: Ayush Singh, Luis Camero
```

## ewellix_examples

```
* Update license in package.xml
* Merge pull request #9 <https://github.com/clearpathrobotics/ewellix_lift/issues/9> from clearpathrobotics/feature/viz
  Feature:  Move RViz and Simulation to ewellix_lift_common
* Move RViz and Simulation to ewellix_lift_common
* Update ign to gz in dependencies
* Migrate gazebo away from ignition
* Contributors: Luis Camero
```
