### PR TITLE
ewellix_lift: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -214,15 +214,12 @@ repositories:
       version: humble
     release:
       packages:
-      - ewellix_description
       - ewellix_driver
       - ewellix_examples
-      - ewellix_interfaces
-      - ewellix_moveit_config
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/ewellix_lift-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/ewellix_lift.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ewellix_lift` to `0.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/ewellix_lift.git
- release repository: https://github.com/clearpath-gbp/ewellix_lift-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-1`

## ewellix_driver

```
* Update license in package.xml
* Merge pull request #7 <https://github.com/clearpathrobotics/ewellix_lift/issues/7> from Ayush1285/feat/last-position
  Update the initial state of the lift.
* Merge pull request #4 <https://github.com/clearpathrobotics/ewellix_lift/issues/4> from Ayush1285/humble
  Encoder limits as configurable parameters
* Fetch prev position
* Added encoder limit struct
* Added upper and lower limits as member variables
* Added encoder lower and upper limits params.
* Contributors: Ayush Singh, Luis Camero
```

## ewellix_examples

```
* Update license in package.xml
* Move RViz and Simulation to ewellix_lift_common
* Contributors: Luis Camero
```
