### PR TITLE
ewellix_lift_common: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -225,6 +225,28 @@ repositories:
       url: https://github.com/clearpathrobotics/ewellix_lift.git
       version: humble
     status: developed
+  ewellix_lift_common:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/ewellix_lift_common.git
+      version: humble
+    release:
+      packages:
+      - ewellix_description
+      - ewellix_interfaces
+      - ewellix_lift_common
+      - ewellix_moveit_config
+      - ewellix_sim
+      - ewellix_viz
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/ewellix_lift_common-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/ewellix_lift_common.git
+      version: humble
+    status: maintained
   flir_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ewellix_lift_common` to `0.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/ewellix_lift_common.git
- release repository: https://github.com/clearpath-gbp/ewellix_lift_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ewellix_description

```
* Add argument to disable mount and base plates
* Update license entry in package.xml
* Add mount plate mesh
* Add UR620 meshes and config
* Contributors: Luis Camero
```

## ewellix_interfaces

- No changes

## ewellix_lift_common

```
* Update documentation with Gazebo instructions
* Initial update  to ewellix_lift_common docs
* Add metapackage for common packages
* Contributors: Luis Camero
```

## ewellix_moveit_config

```
* Add acceleration limits and mount link to SRDF
* Update license entry in package.xml
* Contributors: Luis Camero
```

## ewellix_sim

```
* Update license entry in package.xml
* Revert to ign
* Add visualization and simulation packages
* Contributors: Luis Camero
```

## ewellix_viz

```
* Update license entry in package.xml
* Add visualization and simulation packages
* Contributors: Luis Camero
```
