### PR TITLE
clearpath_config: 2.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -91,7 +91,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.6.2-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.7.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.2-1`

## clearpath_config

```
* Drivetrains (#178 <https://github.com/clearpathrobotics/clearpath_config/issues/178>)
  * Added drivetrain support
  * Split 2wd into fwd and rwd
  * Added samples
  * Renamed drivetrain 'type' to 'control'
  * Split wheels into front and rear
  * Added caster wheel
  * Removed 2WD options for Dingo-O and Ridgeback
  * Changed J100, A200, W200 to 4WD
  * Reset the global serial number variable
  * Fixed A300 sample drivetrain section
  * Added drivetrain to other platform outline samples
  * Fixed Dingo-D control type
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Add the 2d lidar to the wireless charger (#181 <https://github.com/clearpathrobotics/clearpath_config/issues/181>)
* Contributors: Chris Iverach-Brereton, Roni Kreinin
```
