### PR TITLE
clearpath_common: 2.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -76,7 +76,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.6.4-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.7.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.4-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

```
* Drivetrains (#237 <https://github.com/clearpathrobotics/clearpath_common/issues/237>)
  * Moved meshes to wheels folder
  Mecanum drivetrain for do100
  * Generic drivetrain URDFs
  * Pass hardware plugin string rather than block
  * Added drivetrain control parameters
  * Removed 2WD for Dingo-O
  * DO150
  * Dingo-D
  * R100
  * A300 urdf
  * Fixed xacro generate print
  * Generic teleop configs per controller
  Platform specific teleop only defines velocity limits
  * A200 drivetrain changes
  * W200 drivetrain urdf
  * Updated A300 meshes
  Mecanum and caster support
  * Separated caster wheel into swivel and wheel links
  * Fixed joystick axis mapping
  * Updated wheel_separation_multiplier for fwd and rwd on A300
  * URDF structure changes for J100
  Updated A200 and W200 to be 4WD
  * Linting
* Contributors: Roni Kreinin
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

```
* Added MCU alerts to diagnostics (#248 <https://github.com/clearpathrobotics/clearpath_common/issues/248>)
  * Added MCU alerts to diagnostics
  * Linting
* Contributors: Roni Kreinin
```

## clearpath_generator_common

```
* Drivetrains (#237 <https://github.com/clearpathrobotics/clearpath_common/issues/237>)
  * Moved meshes to wheels folder
  Mecanum drivetrain for do100
  * Generic drivetrain URDFs
  * Pass hardware plugin string rather than block
  * Added drivetrain control parameters
  * Removed 2WD for Dingo-O
  * DO150
  * Dingo-D
  * R100
  * A300 urdf
  * Fixed xacro generate print
  * Generic teleop configs per controller
  Platform specific teleop only defines velocity limits
  * A200 drivetrain changes
  * W200 drivetrain urdf
  * Updated A300 meshes
  Mecanum and caster support
  * Separated caster wheel into swivel and wheel links
  * Fixed joystick axis mapping
  * Updated wheel_separation_multiplier for fwd and rwd on A300
  * URDF structure changes for J100
  Updated A200 and W200 to be 4WD
  * Linting
* Feature/monitor default sensors (#240 <https://github.com/clearpathrobotics/clearpath_common/issues/240>)
  * Monitor default platform IMUs
  * Monitor default platform GPS
* Contributors: Hilary Luo, Roni Kreinin
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Add ewellix_description to package.xml (#251 <https://github.com/clearpathrobotics/clearpath_common/issues/251>)
* Contributors: luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Drivetrains (#237 <https://github.com/clearpathrobotics/clearpath_common/issues/237>)
  * Moved meshes to wheels folder
  Mecanum drivetrain for do100
  * Generic drivetrain URDFs
  * Pass hardware plugin string rather than block
  * Added drivetrain control parameters
  * Removed 2WD for Dingo-O
  * DO150
  * Dingo-D
  * R100
  * A300 urdf
  * Fixed xacro generate print
  * Generic teleop configs per controller
  Platform specific teleop only defines velocity limits
  * A200 drivetrain changes
  * W200 drivetrain urdf
  * Updated A300 meshes
  Mecanum and caster support
  * Separated caster wheel into swivel and wheel links
  * Fixed joystick axis mapping
  * Updated wheel_separation_multiplier for fwd and rwd on A300
  * URDF structure changes for J100
  Updated A200 and W200 to be 4WD
  * Linting
* Add the mounting link for the charger's 2D lidar (#241 <https://github.com/clearpathrobotics/clearpath_common/issues/241>)
* Contributors: Chris Iverach-Brereton, Roni Kreinin
```

## clearpath_sensors_description

- No changes
