### PR TITLE
clearpath_robot: 2.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -168,7 +168,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.6.3-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.7.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.3-1`

## clearpath_generator_robot

```
* Fix: OAK-D Parameters (#260 <https://github.com/clearpathrobotics/clearpath_robot/issues/260>)
* Contributors: luis-camero
```

## clearpath_hardware_interfaces

```
* Drivetrains (#250 <https://github.com/clearpathrobotics/clearpath_robot/issues/250>)
  * Allow for only 2 motors in fan control node
  * Fixed logic
  * Added 2 joint support for lynx hardware
  * Switch to using motor protection message
* Contributors: Roni Kreinin
```

## clearpath_robot

```
* Add ewellix_driver to pacakge.xml (#264 <https://github.com/clearpathrobotics/clearpath_robot/issues/264>)
* [clearpath_robot] Added missing package list. (#262 <https://github.com/clearpathrobotics/clearpath_robot/issues/262>)
  * [clearpath_robot] Added missing package list.
  * Changed command to get installed package list.
* [clearpath_robot] Remove any lines containing the word 'password' (case insensitive) from netplan files when grabbing diagnostics. (#256 <https://github.com/clearpathrobotics/clearpath_robot/issues/256>)
* Contributors: Tony Baltovski, luis-camero
```

## clearpath_sensors

```
* Remove exec_depend on fixposition driver (#263 <https://github.com/clearpathrobotics/clearpath_robot/issues/263>)
  Update the version requirement in the commented-out block below
* Update Fixposition launch file, parameters to use 8.x driver (#253 <https://github.com/clearpathrobotics/clearpath_robot/issues/253>)
  * Migration of Fixposition 8.x parameters
  * Update topic remaps for new driver version
* Contributors: Chris Iverach-Brereton
```

## clearpath_tests

```
* Added LynxMotorProtection support (#261 <https://github.com/clearpathrobotics/clearpath_robot/issues/261>)
* Contributors: Roni Kreinin
```

## lynx_motor_driver

```
* Drivetrains (#250 <https://github.com/clearpathrobotics/clearpath_robot/issues/250>)
  * Allow for only 2 motors in fan control node
  * Fixed logic
  * Added 2 joint support for lynx hardware
  * Switch to using motor protection message
* Contributors: Roni Kreinin
```

## puma_motor_driver

- No changes
