### PR TITLE
clearpath_desktop: 2.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -111,7 +111,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 2.0.0-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `2.7.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`

## clearpath_config_live

- No changes

## clearpath_desktop

- No changes

## clearpath_offboard_sensors

```
* Update republish arguments as parameters for Jazzy (#23 <https://github.com/clearpathrobotics/clearpath_desktop/issues/23>)
* Contributors: Hilary Luo
```

## clearpath_viz

- No changes
