### PR TITLE
clearpath_simulator: 2.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -202,7 +202,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 2.3.1-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `2.7.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.1-1`

## clearpath_generator_gz

- No changes

## clearpath_gz

```
* Add explicit gravity & realtime update rate to warehouse world (#90 <https://github.com/clearpathrobotics/clearpath_simulator/issues/90>)
  All other worlds include these parameters, so to keep things consistent add them to the Warehouse too.
* Contributors: Chris Iverach-Brereton
```

## clearpath_simulator

- No changes
