### PR TITLE
clearpath_hal: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -117,6 +117,28 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_desktop.git
       version: jazzy
     status: maintained
+  clearpath_hal:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/platform/clearpath_hal.git
+      version: jazzy
+    release:
+      packages:
+      - can_hardware
+      - canopen_motor_hardware
+      - hal_components
+      - hal_launch
+      - hal_signal_interface
+      - hal_signal_manager
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/clearpath_hal-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/platform/clearpath_hal.git
+      version: jazzy
+    status: developed
   clearpath_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_hal` to `0.1.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/platform/clearpath_hal.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/clearpath_hal-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## can_hardware

```
* Initial commit
* Contributors: Natesh Narain
```

## canopen_motor_hardware

```
* Initial commit
* Contributors: Natesh Narain
```

## hal_components

```
* Initial commit
* Contributors: Natesh Narain
```

## hal_launch

```
* Initial commit
* Contributors: Natesh Narain
```

## hal_signal_interface

```
* Initial commit
* Contributors: Natesh Narain
```

## hal_signal_manager

```
* Initial commit
* Contributors: Natesh Narain
```
