### PR TITLE
clearpath_hal_devices: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -139,6 +139,23 @@ repositories:
       url: https://gitlab.clearpathrobotics.com/platform/clearpath_hal.git
       version: jazzy
     status: developed
+  clearpath_hal_devices:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/platform/clearpath_hal_devices.git
+      version: jazzy
+    release:
+      packages:
+      - sevcon_hardware
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/clearpath_hal_devices-gbp.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/platform/clearpath_hal_devices.git
+      version: jazzy
+    status: developed
   clearpath_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_hal_devices` to `0.1.0-1`:

- upstream repository: https://gitlab.clearpathrobotics.com/platform/clearpath_hal_devices.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/clearpath_hal_devices-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## sevcon_hardware

```
* Initial comment
* Contributors: Natesh Narain
```
