### PR TITLE
clearpath_nav2_demos: 2.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -184,7 +184,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_nav2_demos` to `2.7.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
- release repository: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.0-1`

## clearpath_nav2_demos

```
* Fix SLAM parameter rewrites for Jazzy (#31 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/31>)
  * Set the scan_topic parameter to the fully qualified topic, set the map_name parameter
  * Add a note about the scan_topic and map_name parameters getting rewritten by the launch file
* Contributors: Chris Iverach-Brereton
```
