### PR TITLE
clearpath_common: 2.7.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -76,7 +76,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.7.2-1
+      version: 2.7.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.7.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.2-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

```
* Include hidden with foxglove bridge for onav (#261 <https://github.com/clearpathrobotics/clearpath_common/issues/261>)
* Contributors: Hilary Luo
```

## clearpath_generator_common

```
* Skip xacro load for zed camera since wrapper must be manually installed (#263 <https://github.com/clearpathrobotics/clearpath_common/issues/263>)
* Forward Port Feature: Manipulator Extra ROS Parameters (#229 <https://github.com/clearpathrobotics/clearpath_common/issues/229>) (#259 <https://github.com/clearpathrobotics/clearpath_common/issues/259>)
  * Feature: Manipulator Extra ROS Parameters (#229 <https://github.com/clearpathrobotics/clearpath_common/issues/229>)
  * Pass manipulator ros parameters to generated controller file
  * Update platform config parameters
  * Remove pprint
  * Fix parameter replacements
* Contributors: Hilary Luo, luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

```
* Set simulated camera topic (#264 <https://github.com/clearpathrobotics/clearpath_common/issues/264>)
* Contributors: Hilary Luo
```
