### PR TITLE
clearpath_robot: 2.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -207,7 +207,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.7.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.0-1`

## clearpath_generator_robot

```
* Feature: Franka in Jazzy (#266 <https://github.com/clearpathrobotics/clearpath_robot/issues/266>)
  * Feature: Franka Hand (#252 <https://github.com/clearpathrobotics/clearpath_robot/issues/252>)
  * Add frank gripper launch
  * Add manipulators to namespace
  * Add remapping of joint states
  * Fix joint names
  * Define arm_id in joint names to franka_gripper_node
  * Rename franka_gripper node
* Contributors: luis-camero
```

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

```
* Jazzy Fix: Stereolabs Zed launch file (#265 <https://github.com/clearpathrobotics/clearpath_robot/issues/265>)
  * Fix: Stereolabs Zed launch file (#208 <https://github.com/clearpathrobotics/clearpath_robot/issues/208>)
  * Update node parameters
  * Switch to composable node
  * Double to single quotes in Zed parameters
  * Add 'NEURAL_LIGHT' to parameter comment
* Contributors: luis-camero
```

## clearpath_tests

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
