### PR TITLE
clearpath_config: 1.3.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -85,7 +85,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `1.3.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.2-1`

## clearpath_config

```
* Backport Fix: Ouster URDF Parameters (#195 <https://github.com/clearpathrobotics/clearpath_config/issues/195>)
  * Base and Cap parameter to Ouster
  * Add 'cap_type' and 'base_type' in Ouster sample
* Fix: Lift URDF Parameters (#194 <https://github.com/clearpathrobotics/clearpath_config/issues/194>)
* Contributors: luis-camero
```
