### PR TITLE
clearpath_common: 1.3.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -70,7 +70,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.3.6-1
+      version: 1.3.7-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `1.3.7-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.6-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Backport Fix: Ouster URDF Parameters (#266 <https://github.com/clearpathrobotics/clearpath_common/issues/266>)
  * Add base parameter to Ouster URDF
  * Add base and cap to Ouster description generator
* Contributors: luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Fix: Lift URDF Parameters (#267 <https://github.com/clearpathrobotics/clearpath_common/issues/267>)
  Pass 'add_mount' parameter to URDF
* Contributors: luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

```
* Backport Fix: Ouster URDF Parameters (#266 <https://github.com/clearpathrobotics/clearpath_common/issues/266>)
  * Add base parameter to Ouster URDF
  * Add base and cap to Ouster description generator
* Contributors: luis-camero
```
