### PR TITLE
clearpath_robot: 2.7.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -207,7 +207,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.7.1-1
+      version: 2.7.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.7.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.1-1`

## clearpath_generator_robot

```
* Feature: Kinova Jazzy Support (#268 <https://github.com/clearpathrobotics/clearpath_robot/issues/268>)
  * Add Kinova vision node to manipulator launch file
  * Kinova camera rate from string to double
  * Use node name to namespace Kinova camera topics
  * Add Kinova Pointcloud ComposableNodeContainer
  * Fix Kinova processing container remappings
  * Remove unnecessary lines
  * Rename depth registered node
  * Update depth registered node in pointcloud generator
  * Add missing remap to pointcloud processor
  * Lint
* Contributors: luis-camero
```

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

- No changes

## clearpath_tests

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
