### PR TITLE
peplink_router_driver: 0.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -323,6 +323,24 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/micro-ROS-Agent-release.git
       version: 5.0.3-1
+  peplink_router_driver:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/peplink_router_driver.git
+      version: jazzy
+    release:
+      packages:
+      - peplink_msgs
+      - peplink_router_driver
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/peplink_router_driver-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/peplink_router_driver.git
+      version: jazzy
+    status: developed
   ros2_canopen:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `peplink_router_driver` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/peplink_router_driver.git
- release repository: https://github.com/clearpath-gbp/peplink_router_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## peplink_msgs

```
* Initial release
```

## peplink_router_driver

```
* Initial release
```
