### PR TITLE
clearpath_robot: 2.9.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -209,7 +209,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.9.1-1
+      version: 2.9.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.9.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.1-1`

## clearpath_generator_robot

```
* Feature: Generator Sample Tests (#315 <https://github.com/clearpathrobotics/clearpath_robot/issues/315>)
  * Remove empty sensor config directories
  * Ignore non-YAML files in tests
  * Add generator testing to CI
  * Create sensor directory if sensors to generate exist
  * Generate platform extras in robot launch generator
  * Rename README to markdown and add generator tests
* Contributors: luis-camero
```

## clearpath_hardware_interfaces

```
* Fixed unused parameter warning in LynxHardware. (#326 <https://github.com/clearpathrobotics/clearpath_robot/issues/326>)
* Fixed the RB20 battery LUT to fit curve better. (#323 <https://github.com/clearpathrobotics/clearpath_robot/issues/323>)
  * Fixed the RB20 battery LUT to fit curve better.
  * Removed comment from RB20 LUT.
* Updated declarations to fix deprecated warning. (#307 <https://github.com/clearpathrobotics/clearpath_robot/issues/307>)
* Contributors: Tony Baltovski
```

## clearpath_robot

```
* Grab the folders inside the workspaces as well. (#316 <https://github.com/clearpathrobotics/clearpath_robot/issues/316>)
  * Grab the folders inside the workspaces as well.
  * Update clearpath_robot/scripts/grab-diagnostics
  Co-authored-by: Tom Wallis <mailto:thomas.wallis@rockwellautomation.com>
  * Fixed sed alternate delimiter syntax in grab-diagnostics.
  ---------
  Co-authored-by: Tom Wallis <mailto:thomas.wallis@rockwellautomation.com>
* Contributors: Tony Baltovski
```

## clearpath_sensors

```
* Fix OAK-D camera launch, node naming, and point cloud output (#327 <https://github.com/clearpathrobotics/clearpath_robot/issues/327>)
* fix: added missing imu/mag remap for microstrain_imu. (#319 <https://github.com/clearpathrobotics/clearpath_robot/issues/319>)
* Contributors: Tony Baltovski
```

## clearpath_tests

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
