### PR TITLE
clearpath_robot: 1.3.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -167,7 +167,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 1.3.7-1
+      version: 1.3.8-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `1.3.8-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.7-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

```
* Fixed the RB20 battery LUT to fit curve better. (#323 <https://github.com/clearpathrobotics/clearpath_robot/issues/323>) (#325 <https://github.com/clearpathrobotics/clearpath_robot/issues/325>)
  * Fixed the RB20 battery LUT to fit curve better.
  * Removed comment from RB20 LUT.
  (cherry picked from commit 2b2a6ebc1f06898b1623ba66baf61da14bdaed0e)
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Contributors: mergify[bot]
```

## clearpath_robot

```
* Grab the folders inside the workspaces as well. (#316 <https://github.com/clearpathrobotics/clearpath_robot/issues/316>) (#318 <https://github.com/clearpathrobotics/clearpath_robot/issues/318>)
  * Grab the folders inside the workspaces as well.
  * Update clearpath_robot/scripts/grab-diagnostics
  * Fixed sed alternate delimiter syntax in grab-diagnostics.
  ---------
  (cherry picked from commit 3b0211597b20c620843787d681f3e731f1c3c536)
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
  Co-authored-by: Tom Wallis <mailto:thomas.wallis@rockwellautomation.com>
* Contributors: mergify[bot]
```

## clearpath_sensors

```
* [Humble] Fix: added missing imu/mag remap for microstrain_imu. (#320 <https://github.com/clearpathrobotics/clearpath_robot/issues/320>)
  * fix: added missing imu/mag remap for microstrain_imu. (#319 <https://github.com/clearpathrobotics/clearpath_robot/issues/319>)
  (cherry picked from commit afa2a6768729d30fceb665e6c59ca225dc7616ea)
  # Conflicts:
  #     clearpath_sensors/launch/microstrain_imu.launch.py
  * Fixed conflicts.
  ---------
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Contributors: mergify[bot]
```

## puma_motor_driver

```
* [Humble] Changed to rostooling/setup-ros-docker:ubuntu-noble-latest for CI image. (#313 <https://github.com/clearpathrobotics/clearpath_robot/issues/313>)
  * Changed to rostooling/setup-ros-docker:ubuntu-noble-latest for CI image. (#312 <https://github.com/clearpathrobotics/clearpath_robot/issues/312>)
  (cherry picked from commit 6e16b3cbdb3d04b644ba6c6fb3247267059770c9)
  # Conflicts:
  #     .github/workflows/ci.yml
  * Resolve backport conflicts: use rostooling/setup-ros-docker:ubuntu-jammy-latest for Humble CI
  * Add ewellix_driver to ROSDEP_SKIP_KEYS for Humble CI
  * Linting fixes.
  * Updated CI to match Jazzy.
  * Removed --break-system-packages.
  ---------
  Co-authored-by: Tony Baltovski <tbaltovski@clearpathrobotics.com>
* Contributors: mergify[bot]
```
