### PR TITLE
clearpath_common: 2.9.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -61,6 +61,7 @@ repositories:
       version: jazzy
     release:
       packages:
+      - clearpath_bms_broadcaster
       - clearpath_bt_joy
       - clearpath_common
       - clearpath_control
@@ -76,7 +77,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.9.5-1
+      version: 2.9.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.9.6-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.5-1`

## clearpath_bms_broadcaster

```
* remove left and right prefixes
* update and fix tests
* remove changelog and update package version
* CORE-36992: Add battery state broadcaster
* Contributors: Natesh Narain
* remove left and right prefixes
* update and fix tests
* remove changelog and update package version
* CORE-36992: Add battery state broadcaster
* Contributors: Natesh Narain
```

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

```
* Feature: Generator Sample Tests (#294 <https://github.com/clearpathrobotics/clearpath_common/issues/294>)
  * Add clearpath_generator_tests to dependencies.repos
  * Increase pose trials to 10000
  * Add CI test to build and tests generators
  * Ignore non-YAML files in tests
  * Update CI to use common tests
  * Use the setup image
  * Generate moveit.yaml in alphabetical order
  * Remove unconditional creation of sensor and platform extras directories
  * Initial add of README with generator tests
  * Use pathlib to find extension
* Contributors: luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
