### PR TITLE
flir_ptu: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -290,6 +290,25 @@ repositories:
       url: https://github.com/clearpathrobotics/ewellix_lift_common.git
       version: jazzy
     status: maintained
+  flir_ptu:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: ros2
+    release:
+      packages:
+      - flir_ptu_description
+      - flir_ptu_driver
+      - flir_ptu_viz
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/flir_ptu-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: ros2
+    status: maintained
   inventus_bmu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `1.0.0-1`:

- upstream repository: https://github.com/ros-drivers/flir_ptu.git
- release repository: https://github.com/clearpath-gbp/flir_ptu-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## flir_ptu_description

```
* Added sim support, fixed function naming.
* Updated to ROS 2.
* Contributors: Tony Baltovski
```

## flir_ptu_driver

```
* Added sim support, fixed function naming.
* Linting.
* Updated to ROS 2.
* Contributors: Tony Baltovski
```

## flir_ptu_viz

```
* Linting.
* Updated to ROS 2.
* Contributors: Tony Baltovski
```
