### PR TITLE
clearpath_simulator: 2.9.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -244,7 +244,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 2.9.0-1
+      version: 2.9.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `2.9.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.0-1`

## clearpath_generator_gz

```
* Feature: Generator Sample Tests (#107 <https://github.com/clearpathrobotics/clearpath_simulator/issues/107>)
  * Add generic platform to look up table
  * Add generator tests to CI
  * Create sensor directory only if sensors are present
  * Only run base CI if PR
  * Add generator tests to README
* Contributors: luis-camero
```

## clearpath_gz

```
* Fix: robot_spawn.launch.py fails with generate:=false (#110 <https://github.com/clearpathrobotics/clearpath_simulator/issues/110>)
  * Fix: robot_spawn.launch.py fails with generate:=false
  Use UnlessCondition with the launch configuration directly instead of
  bool() on the perform()ed string (which is always truthy for non-empty
  strings, including 'false'). This restores the Humble behaviour where
  generate:=false correctly spawns the robot without regenerating files.
  Fixes #91 <https://github.com/clearpathrobotics/clearpath_simulator/issues/91>
  * Wrap generate actions in GroupAction to mirror humble structure
* Contributors: Tony Baltovski
```

## clearpath_simulator

- No changes
