### PR TITLE
flir_ptu: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -266,6 +266,25 @@ repositories:
       url: https://github.com/ros-drivers/flir_camera_driver.git
       version: humble-devel
     status: maintained
+  flir_ptu:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: ros2
+    release:
+      packages:
+      - flir_ptu_description
+      - flir_ptu_driver
+      - flir_ptu_viz
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/flir_ptu-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: ros2
+    status: maintained
   micro_ros_agent:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `1.0.2-1`:

- upstream repository: https://github.com/ros-drivers/flir_ptu.git
- release repository: https://github.com/clearpath-gbp/flir_ptu-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## flir_ptu_description

```
* Move the mount_link to the mounting point
* Contributors: Luis Camero
```

## flir_ptu_driver

- No changes

## flir_ptu_viz

- No changes
