### PR TITLE
clearpath_config: 2.9.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -92,7 +92,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.9.1-1
+      version: 2.9.2-1
     source:
       type: git
       url: https://gitlab.clearpathrobotics.com/research/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.9.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.1-1`

## clearpath_config

```
* Feature: PTU (#222 <https://github.com/clearpathrobotics/clearpath_config/issues/222>)
  * Added support for Flir PTU-5.
  * Se the joint_name_prefix based on the ID of the PTU
  ---------
  Co-authored-by: Luis Camero <mailto:lcamero@clearpathrobotics.com>
* Feature: Generator Sample Tests (#219 <https://github.com/clearpathrobotics/clearpath_config/issues/219>)
  * Add testing samples
  * Add Warthog and mounts sample test
  * Disable testing on Zed
  * Remove franka from tests
  * Updated README with generator tests
* Changed to rostooling/setup-ros-docker:ubuntu-noble-latest for CI image. (#216 <https://github.com/clearpathrobotics/clearpath_config/issues/216>)
* Contributors: Tony Baltovski, luis-camero
```
