### PR TITLE
clearpath_common: 2.9.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -77,7 +77,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.9.7-1
+      version: 2.9.8-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.9.8-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.7-1`

## clearpath_bms_broadcaster

- No changes

## clearpath_bt_joy

```
* Added support for Fort VSC joy. (#341 <https://github.com/clearpathrobotics/clearpath_common/issues/341>)
  * Added support for Fort VSC joy.
  * Removed bluetooth node.
* Contributors: Tony Baltovski
```

## clearpath_common

- No changes

## clearpath_control

```
* Added support for Fort VSC joy. (#341 <https://github.com/clearpathrobotics/clearpath_common/issues/341>)
  * Added support for Fort VSC joy.
  * Removed bluetooth node.
* Contributors: Tony Baltovski
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

- No changes

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
