### PR TITLE
nmea_navsat_driver: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -345,6 +345,21 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/micro-ROS-Agent-release.git
       version: 5.0.3-1
+  nmea_navsat_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: ros2
+    status: maintained
   numato_relay:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `2.0.1-1`:

- upstream repository: https://github.com/ros-drivers/nmea_navsat_driver.git
- release repository: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## nmea_navsat_driver

```
* Fix parsing of true_course field in VTG message (#165 <https://github.com/evenator/nmea_navsat_driver/issues/165>)
  Co-authored-by: Stefan Gisler <mailto:stefan.gisler@hillbot.ch>
* Fix missing return in driver.add_sentence to avoid returning None.
* Update logger definition to match ROS2 logging API.
* Add Support for TCP GNSS Sensor (#152 <https://github.com/evenator/nmea_navsat_driver/issues/152>)
  Add a new nmea_tcpclient_driver for sensors that offer a TCP interface rather than a UDP interface.
  The nmea_tcpclient_driver connects to a TCP socket and forwards the NMEA-Sentences line-by-line to the driver.
* Modify setup.cfg to remove warning when doing colcon build (#157 <https://github.com/evenator/nmea_navsat_driver/issues/157>)
* Contributors: Dunkelmann, Luca Bascetta, gislers, joeldushouyu
```
