### PR TITLE
ros2_canopen: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -427,6 +427,10 @@ repositories:
       version: jazzy
     status: developed
   ros2_canopen:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/ros2_canopen.git
+      version: master
     release:
       packages:
       - canopen
@@ -445,7 +449,12 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpathrobotics/ros2_canopen-release.git
-      version: 0.3.3-1
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/ros2_canopen.git
+      version: master
+    status: maintained
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.4.0-1`:

- upstream repository: https://github.com/clearpathrobotics/ros2_canopen.git
- release repository: https://github.com/clearpathrobotics/ros2_canopen-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.3-1`

## canopen

- No changes

## canopen_402_driver

- No changes

## canopen_base_driver

- No changes

## canopen_core

- No changes

## canopen_fake_slaves

- No changes

## canopen_interfaces

- No changes

## canopen_master_driver

- No changes

## canopen_proxy_driver

- No changes

## canopen_ros2_control

- No changes

## canopen_ros2_controllers

- No changes

## canopen_tests

- No changes

## canopen_utils

- No changes

## lely_core_libraries

- No changes
