### PR TITLE
nmea_navsat_driver: 2.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -306,6 +306,20 @@ repositories:
         release: release/humble/{package}/{version}
       url: http://gitlab.clearpathrobotics.com/gbp/microhard_snmp-gbp.git
       version: 1.0.0-1
+  nmea_navsat_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
+      version: 2.0.4-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: ros2
   numato_relay:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `2.0.4-1`:

- upstream repository: https://github.com/clearpathrobotics/nmea_navsat_driver.git
- release repository: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## nmea_navsat_driver

```
* Removed tf_transformations dependency.
* Contributors: Tony Baltovski
```
