### PR TITLE
nmea_navsat_driver: 2.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -354,7 +354,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
-      version: 2.0.1-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `2.0.4-1`:

- upstream repository: https://github.com/clearpathrobotics/nmea_navsat_driver.git
- release repository: https://github.com/clearpath-gbp/nmea_navsat_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-1`

## nmea_navsat_driver

```
* Removed tf_transformations dependency.
* Contributors: Tony Baltovski
```
