### PR TITLE
clearpath_common: 2.9.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -77,7 +77,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.9.9-1
+      version: 2.9.10-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.9.10-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.9-1`

## clearpath_bms_broadcaster

- No changes

## clearpath_bt_joy

```
* Added support for the PS5 joystick and created an actual cutoff to de… (#342 <https://github.com/clearpathrobotics/clearpath_common/issues/342>)
  * Added support for the PS5 joystick and created an actual cutoff to detect when it about to disconnect.
  * Added more fine grained udev rules to ensuring the mapping is on the correct joy.
  * Updated README.
  * Added pairing script.
  * Minor changes.
  * Updated copyright to Rockwell Automation.
* Contributors: Tony Baltovski
```

## clearpath_common

- No changes

## clearpath_control

```
* Added support for the PS5 joystick and created an actual cutoff to de… (#342 <https://github.com/clearpathrobotics/clearpath_common/issues/342>)
  * Added support for the PS5 joystick and created an actual cutoff to detect when it about to disconnect.
  * Added more fine grained udev rules to ensuring the mapping is on the correct joy.
  * Updated README.
  * Added pairing script.
  * Minor changes.
  * Updated copyright to Rockwell Automation.
* Contributors: Tony Baltovski
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

- No changes

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
