### PR TITLE
clearpath_simulator: 2.9.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -244,7 +244,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 2.9.2-1
+      version: 2.9.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `2.9.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.2-1`

## clearpath_generator_gz

- No changes

## clearpath_gz

```
* Added automapping for teleop topic on Gazebo GUI. (#115 <https://github.com/clearpathrobotics/clearpath_simulator/issues/115>)
* Contributors: Tony Baltovski
```

## clearpath_simulator

- No changes
