### PR TITLE
clearpath_common: 2.9.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -77,7 +77,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.9.10-2
+      version: 2.9.11-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.9.11-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.10-2`

## clearpath_bms_broadcaster

- No changes

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

```
* Fixed failing controllers by using single spawner call to avoid competing for the ros2-control file lock.
* Contributors: Tony Baltovski
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

- No changes

## clearpath_manipulators

```
* Fixed failing controllers by usingsingle spawner call to avoid competing for the ros2-control file lock.
* Contributors: Tony Baltovski
```

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
