### PR TITLE
wireless: 1.1.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -601,7 +601,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 1.1.5-1
+      version: 1.1.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.1.6-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.5-1`

## wireless_msgs

```
* Removed lint test and fixed deps for msgs.
* Added precommit, dependabot, CI, mergify and issue template.
* Contributors: Tony Baltovski
```

## wireless_watcher

```
* Added the dormant state as still being connected. (#30 <https://github.com/clearpathrobotics/wireless/issues/30>)
* Removed lint test and fixed deps for msgs.
* Added precommit, dependabot, CI, mergify and issue template.
* Contributors: Tony Baltovski
```
