### PR TITLE
clearpath_robot: 2.9.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -210,7 +210,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.9.3-1
+      version: 2.9.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.9.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.3-1`

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

```
* [clearpath_sensors] Updated Stereolabs Zed pos_tracking_mode to GEN_3. (#338 <https://github.com/clearpathrobotics/clearpath_robot/issues/338>)
* Contributors: Tony Baltovski
```

## clearpath_tests

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
