### PR TITLE
clearpath_robot: 1.3.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -167,7 +167,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 1.3.8-1
+      version: 1.3.9-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `1.3.9-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.8-1`

## clearpath_diagnostics

- No changes

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

- No changes

## clearpath_robot

- No changes

## clearpath_sensors

```
* [Humble] [clearpath_sensors] Updated Stereolabs Zed pos_tracking_mode to GEN_3. (#339 <https://github.com/clearpathrobotics/clearpath_robot/issues/339>)
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Contributors: mergify[bot]
```

## puma_motor_driver

- No changes
