### PR TITLE
clearpath_common: 2.9.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -77,7 +77,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.9.11-1
+      version: 2.9.12-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.9.12-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.11-1`

## clearpath_bms_broadcaster

- No changes

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

```
* Fixed controller spawner to run in both simulation and real hardware as reported as bug in #363 <https://github.com/clearpathrobotics/clearpath_common/issues/363>. (#364 <https://github.com/clearpathrobotics/clearpath_common/issues/364>)
* Contributors: Tony Baltovski
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

```
* Fixed bash writer to use single quotes for values containing double q… (#365 <https://github.com/clearpathrobotics/clearpath_common/issues/365>)
  * Fixed bash writer to use single quotes for values containing double quotes.
* Contributors: Tony Baltovski
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Added support for A300 witn indoor tires. (#362 <https://github.com/clearpathrobotics/clearpath_common/issues/362>)
* Contributors: Tony Baltovski
```

## clearpath_sensors_description

- No changes
