### PR TITLE
clearpath_simulator: 2.9.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -244,7 +244,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 2.9.3-1
+      version: 2.9.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `2.9.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.3-1`

## clearpath_generator_gz

```
* Fixed the name of the imu_filter node to match what is being launched. (#117 <https://github.com/clearpathrobotics/clearpath_simulator/issues/117>)
* Contributors: Tony Baltovski
```

## clearpath_gz

- No changes

## clearpath_simulator

- No changes
