### PR TITLE
clearpath_robot: 2.9.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -210,7 +210,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_robot-release.git
-      version: 2.9.4-1
+      version: 2.9.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_robot` to `2.9.5-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_robot.git
- release repository: https://github.com/clearpath-gbp/clearpath_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.4-1`

## clearpath_generator_robot

- No changes

## clearpath_hardware_interfaces

```
* Adjust Steps in Low Battery Sequence (#340 <https://github.com/clearpathrobotics/clearpath_robot/issues/340>)
  RPSW-2621
  Adjusted the lighting for the "State::LowBattery" by:
  - changing pulse sequence steps to MS_TO_STEPS(2000)
  - changed COLOR_ORANGE = hsv_t(10.0, 100.0, 25.0);
  - changed COLOR_ORANGE_DARK = hsv_t(10.0, 100.0, 0.0);
  In this way the colour is more orange and switches
  more quickly to black to make the state more clear.
  Co-authored-by: Mark Ibrahim <mibrahim@clearpathrobotics.com>
* Contributors: mibrahim-cpr
```

## clearpath_robot

- No changes

## clearpath_sensors

```
* Fixed missing dep for flir_ptu_driver. (#341 <https://github.com/clearpathrobotics/clearpath_robot/issues/341>)
* Contributors: Tony Baltovski
```

## clearpath_tests

- No changes

## lynx_motor_driver

- No changes

## puma_motor_driver

- No changes
