### PR TITLE
clearpath_common: 1.3.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -70,7 +70,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.3.11-1
+      version: 1.3.12-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `1.3.12-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.11-1`

## clearpath_common

- No changes

## clearpath_control

```
* Fixed the name of the imu_filter node to match what is being launched. (#368 <https://github.com/clearpathrobotics/clearpath_common/issues/368>) (#369 <https://github.com/clearpathrobotics/clearpath_common/issues/369>)
  (cherry picked from commit b1308d337489c21f7085c3dbccbb2250d662b6f4)
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Fixed controller spawner to run in both simulation and real hardware as reported as bug in #363 <https://github.com/clearpathrobotics/clearpath_common/issues/363>. (#364 <https://github.com/clearpathrobotics/clearpath_common/issues/364>)
  (cherry picked from commit 8a91ce9669e0c9a500aed8d2f3023d2fcc6c8abb)
* Fixed failing controllers by using  single spawner call to avoid competing for the ros2-control file lock. (#361 <https://github.com/clearpathrobotics/clearpath_common/issues/361>)
  * Fixed the launch order by launching platform_velocity_controller spawner only after joint_state_broadcaster
  spawner exits.
  * Fixed failing controllers by using  single spawner call to avoid competing for the ros2-control file lock.
  (cherry picked from commit 3222709ef156957e7694148a780272aac80924b8)
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Contributors: Tony Baltovski, mergify[bot]
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

- No changes

## clearpath_manipulators

```
* Fixed failing controllers by using  single spawner call to avoid competing for the ros2-control file lock. (#361 <https://github.com/clearpathrobotics/clearpath_common/issues/361>)
  * Fixed the launch order by launching platform_velocity_controller spawner only after joint_state_broadcaster
  spawner exits.
  * Fixed failing controllers by using  single spawner call to avoid competing for the ros2-control file lock.
  (cherry picked from commit 3222709ef156957e7694148a780272aac80924b8)
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Contributors: mergify[bot]
```

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Update hams.urdf.xacro (#373 <https://github.com/clearpathrobotics/clearpath_common/issues/373>) (#376 <https://github.com/clearpathrobotics/clearpath_common/issues/376>)
  Fixed the HAMS mount plate rotation by setting parent to hams_base_link instead of default_mount
  (cherry picked from commit e09854508153c9469dde12ae68f1200445c01304)
  Co-authored-by: thickey-cpr <mailto:thickey@clearpathrobotics.com>
* Contributors: mergify[bot]
```

## clearpath_sensors_description

- No changes
